### PR TITLE
[GSS-36] Secret Manager 기초 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application-local.yml
+/src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -38,15 +44,12 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	//Secret-Manager
-	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.3'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws-secrets-manager-config:2.2.6.RELEASE'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 	implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.8'
 
 	//TEST
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 
 	//Secret-Manager
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
-	implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.8'
 
 	//TEST
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.1"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	//Secret-Manager
+	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.3'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws-secrets-manager-config:2.2.6.RELEASE'
+	implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.8'
+
 	//TEST
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,3 @@ spring:
     hibernate:
       ddl-auto: validate
     defer-datasource-initialization: false
-
-#test:
-#  answer: ${dbInstanceIdentifier}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,16 +1,20 @@
-#spring:
-#  datasource:
-#    driver-class-name: com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver
-#    url: jdbc-secretsmanager:mysql://gss-rds-an2.c7g2k44mupla.ap-northeast-2.rds.amazonaws.com:3306?secretArn=${secrets.rds.arn}
-#  jpa:
-#    show-sql: true
-#    properties:
-#      hibernate:
-#        format_sql: true
-#        dialect: org.hibernate.dialect.MySQLDialect
-#    hibernate:
-#      ddl-auto: validate
-#    defer-datasource-initialization: false
-#
+spring:
+  config:
+    import: 'aws-secretsmanager:dev/devoops/rds'
+  datasource:
+    driver-class-name: com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver
+    url: jdbc-secretsmanager:mysql://gss-rds-an2.c7g2k44mupla.ap-northeast-2.rds.amazonaws.com:3306
+    username: ${username}
+    password: ${password}
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: validate
+    defer-datasource-initialization: false
+
 #test:
-#  answer: coli
+#  answer: ${dbInstanceIdentifier}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,11 +1,6 @@
 spring:
   config:
-    import: 'aws-secretsmanager:dev/devoops/rds'
-  datasource:
-    driver-class-name: com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver
-    url: jdbc-secretsmanager:mysql://gss-rds-an2.c7g2k44mupla.ap-northeast-2.rds.amazonaws.com:3306
-    username: ${username}
-    password: ${password}
+    import: 'aws-secretsmanager:dev/devoops/secrets'
   jpa:
     show-sql: true
     properties:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,16 @@
+#spring:
+#  datasource:
+#    driver-class-name: com.amazonaws.secretsmanager.sql.AWSSecretsManagerMySQLDriver
+#    url: jdbc-secretsmanager:mysql://gss-rds-an2.c7g2k44mupla.ap-northeast-2.rds.amazonaws.com:3306?secretArn=${secrets.rds.arn}
+#  jpa:
+#    show-sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true
+#        dialect: org.hibernate.dialect.MySQLDialect
+#    hibernate:
+#      ddl-auto: validate
+#    defer-datasource-initialization: false
+#
+#test:
+#  answer: coli

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: 'devoops'
+  profiles:
+    default: local
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,0 +1,7 @@
+#aws:
+#  secretsmanager:
+#    name: devoops
+#cloud:
+#  aws:
+#    region:
+#      static: ap-northeast-2

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,7 +1,0 @@
-#aws:
-#  secretsmanager:
-#    name: devoops
-#cloud:
-#  aws:
-#    region:
-#      static: ap-northeast-2


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-36

# 🔂 변경 내역

- H2 DB를 기반으로 application-local.yml 파일을 노션 (보물 창고)에 문서화해놓았습니다.
- application-dev.yml 파일을 기준으로 rds설정을 secret manager를 활용해 구성하였습니다.
<img width="830" alt="image" src="https://github.com/user-attachments/assets/36be4559-00ba-4186-97b3-c67dba33daff" />

- test api를 하나 뚫어 rds 인스턴스 정보를 반환하도록 테스트해본 결과 secret manager와 잘 바인딩 된 모습을 볼 수 있습니다.
```java
@RestController
public class TestController {

    @Value("${test.answer}")
    private String name;

    @GetMapping("/")
    public String test() {
        return name;
    }
}
```

결과
<img width="830" alt="image" src="https://github.com/user-attachments/assets/195fa6b9-b141-4a3c-91a2-ec95aee79797" />

**-> RDS 정보가 secret-manager로 부터 잘 주입됨**


# 🗣️ 리뷰 요구사항 (선택)

### secret maanger 테스트 하는 방법

1) aws cli 설정
간싱싱 [계정/링크란](https://www.notion.so/bbc60269b61d4909911180e58b1fdc70)에 server-iam 엑세스 키를 기반으로 CLI 를 설정합니다.

2) profile 설정
IDE에서 profile을 dev로 설정합니다.

3) 애플리케이션 실행
RDS 와의 연결정보를 secret maanger로 부터 바인딩 받아 성공적으로 잘 연결하는 로그를 볼 수 있습니다.
<img width="830" alt="image" src="https://github.com/user-attachments/assets/6ace0d59-397d-4068-89f8-f7af690c8c5c" />
