### PR TITLE
[GSS-49] Exception & Handler 세팅

### DIFF
--- a/src/main/java/com/devoops/exception/ErrorResponse.java
+++ b/src/main/java/com/devoops/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.devoops.exception;
+
+import com.devoops.exception.errorcode.ErrorCode;
+import jakarta.validation.constraints.NotBlank;
+
+public record ErrorResponse(
+        @NotBlank String code,
+        @NotBlank String status,
+        @NotBlank String message
+) {
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this(
+                errorCode.name(),
+                errorCode.getStatus().name(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/devoops/exception/custom/GssException.java
+++ b/src/main/java/com/devoops/exception/custom/GssException.java
@@ -1,0 +1,13 @@
+package com.devoops.exception.custom;
+
+import com.devoops.exception.errorcode.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+public class GssException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.devoops.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    //4XX
+    FIELD_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
+    URL_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "입력한 값의 타입이 잘못되었습니다."),
+    NO_RESOURCE_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
+    MEDIA_TYPE_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "허용되지 않은 미디어 타입입니다."),
+    ALREADY_DISCONNECTED(HttpStatus.BAD_REQUEST, "이미 클라이언트에서 요청이 종료되었습니다."),
+
+    //5XX
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다. 관리자에게 문의하세요."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/devoops/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/devoops/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.devoops.exception.handler;
+
+
+import com.devoops.exception.ErrorResponse;
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindingException(BindException exception) {
+        return toResponse(ErrorCode.FIELD_ERROR);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException exception) {
+        return toResponse(ErrorCode.URL_PARAMETER_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException exception) {
+        return toResponse(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
+    }
+
+    @ExceptionHandler(ClientAbortException.class)
+    public ResponseEntity<ErrorResponse> handleClientAbortException(ClientAbortException exception) {
+        return toResponse(ErrorCode.ALREADY_DISCONNECTED);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException exception
+    ) {
+        return toResponse(ErrorCode.METHOD_NOT_SUPPORTED);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException exception
+    ) {
+        return toResponse(ErrorCode.MEDIA_TYPE_NOT_SUPPORTED);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException exception) {
+        return toResponse(ErrorCode.NO_RESOURCE_FOUND);
+    }
+
+    @ExceptionHandler(GssException.class)
+    public ResponseEntity<ErrorResponse> handleGssException(GssException exception) {
+        return toResponse(exception.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        return toResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> toResponse(ErrorCode errorCode) {
+        ErrorResponse errorResponse = new ErrorResponse(errorCode);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(errorResponse);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-49


# 🔂 변경 내역

합의했던 내용들을 기반으로 errorResponse와 핸들러를 구현합니다.
추후 멀티모듈 세팅 후, 패키지 이전 예정입니다.

1) 에러 핸들링 전략

- 컨트롤러 단으로 넘어오기 이전에 터지는 에러의 경우, 별도의 처리를 해주었습니다.'

|                **error**               |                                     **설명**                                    | **반환**               |
|:--------------------------------------:|:-------------------------------------------------------------------------------:|------------------------|
| BindException                          | 폼 데이터를 Java 객체에 바인딩할 때, 해당 데이터가 객체의 필드에 맞지 않을 경우 | BAD_REQUEST            |
| ConstraintViolationException           | Bean validation 실패                                                            | BAD_REQUES             |
| MethodArgumentTypeMismatchException    | 컨트롤러 메서드에서 요청 파라미터를 바인딩 시 타입 불일치                       | BAD_REQUEST            |
| ClientAbortException                   | 클라이언트가 응답을 받기 전에 연결을 강제로 종료                                | BAD_REQUEST            |
| HttpRequestMethodNotSupportedException | 지원되지 않는 HTTP 메서드로 요청을 보냈을 때                                    | METHOD_NOT_ALLOWED,    |
| NoResourceFoundException               | 존재하지 않는 리소스 조회 시                                                    | NOT_FOUND              |
| HttpMediaTypeNotSupportedException     | HTTP 요청 본문의 미디어 타입이 지원하지 않는 형식일 때                          | UNSUPPORTED_MEDIA_TYPE |
| GssException                 | 커스텀 에러                                                          | errorCode에 정의된 status                   |
| Exception                              | 그 외 에러                                                                      | INTERNAL_SERVER_ERROR  |



- errorResponse의 경우, 몇몇 프론트 라이브러리에서 헤더를 인식하지 못하는 문제 + 정우의 의견(status 있으면 좋을 것 같다)로 status를 유지하도록 하였습니다.

```java
public record ErrorResponse(
        @NotBlank String code,
        @NotBlank String status,
        @NotBlank String message
) {

    public ErrorResponse(ErrorCode errorCode) {
        this(
                errorCode.name(),
                errorCode.getStatus().name(),
                errorCode.getMessage()
        );
    }
}
```


# 🗣️ 리뷰 요구사항 (선택)
