### PR TITLE
[GSS-81] 회고 CRUD API 구현

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -1,0 +1,14 @@
+package com.devoops.controller.question;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class QuestionController {
+
+    @PostMapping("/api/questions/{questionId}/answer")
+    public ResponseEntity<Void> createAnswer() {
+        return null;
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -1,6 +1,7 @@
 package com.devoops.controller.question;
 
 import com.devoops.controller.auth.AuthUser;
+import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.response.AnswerSaveResponse;
 import com.devoops.service.question.QuestionService;
@@ -21,6 +22,8 @@ public class QuestionController {
             @AuthUser User user,
             @PathVariable(name = "questionId") long questionId
     ) {
-        return null;
+        Answer answer = questionService.saveAnswer(questionId, user);
+        AnswerSaveResponse response = new AnswerSaveResponse(answer);
+        return ResponseEntity.ok(response);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -1,14 +1,26 @@
 package com.devoops.controller.question;
 
+import com.devoops.controller.auth.AuthUser;
+import com.devoops.domain.entity.user.User;
+import com.devoops.dto.response.AnswerSaveResponse;
+import com.devoops.service.question.QuestionService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class QuestionController {
 
+    private final QuestionService questionService;
+
     @PostMapping("/api/questions/{questionId}/answer")
-    public ResponseEntity<Void> createAnswer() {
+    public ResponseEntity<AnswerSaveResponse> createAnswer(
+            @AuthUser User user,
+            @PathVariable(name = "questionId") long questionId
+    ) {
         return null;
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -22,7 +22,7 @@ public class QuestionController {
             @AuthUser User user,
             @PathVariable(name = "questionId") long questionId
     ) {
-        Answer answer = questionService.saveAnswer(questionId, user);
+        Answer answer = questionService.initializeAnswer(questionId, user);
         AnswerSaveResponse response = new AnswerSaveResponse(answer);
         return ResponseEntity.ok(response);
     }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -3,12 +3,16 @@ package com.devoops.controller.question;
 import com.devoops.controller.auth.AuthUser;
 import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.user.User;
+import com.devoops.dto.request.AnswerUpdateRequest;
 import com.devoops.dto.response.AnswerSaveResponse;
+import com.devoops.dto.response.AnswerUpdateResponse;
 import com.devoops.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,6 +28,17 @@ public class QuestionController {
     ) {
         Answer answer = questionService.initializeAnswer(questionId, user);
         AnswerSaveResponse response = new AnswerSaveResponse(answer);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/api/questions/answer/{answerId}")
+    public ResponseEntity<AnswerUpdateResponse> updateAnswer(
+            @AuthUser User user,
+            @PathVariable(name = "answerId") long answerId,
+            @RequestBody AnswerUpdateRequest request
+    ) {
+        Answer updatedAnswer = questionService.updateAnswer(answerId, request.content());
+        AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);
         return ResponseEntity.ok(response);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -2,17 +2,22 @@ package com.devoops.controller.question;
 
 import com.devoops.controller.auth.AuthUser;
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Answers;
 import com.devoops.domain.entity.user.User;
+import com.devoops.dto.request.AnswerPutRequests;
 import com.devoops.dto.request.AnswerUpdateRequest;
+import com.devoops.dto.response.AnswerPutResponses;
 import com.devoops.dto.response.AnswerSaveResponse;
 import com.devoops.dto.response.AnswerUpdateResponse;
 import com.devoops.service.question.QuestionService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,11 +37,21 @@ public class QuestionController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/api/questions/answer")
+    public ResponseEntity<AnswerPutResponses> updateAllAnswer(
+            @AuthUser User user,
+            @Valid @RequestBody AnswerPutRequests request
+    ) {
+        Answers updatedAnswers = questionService.updateAllAnswers(request);
+        AnswerPutResponses response = AnswerPutResponses.from(updatedAnswers);
+        return ResponseEntity.ok(response);
+    }
+
     @PatchMapping("/api/questions/answer/{answerId}")
     public ResponseEntity<AnswerUpdateResponse> updateAnswer(
             @AuthUser User user,
             @PathVariable(name = "answerId") long answerId,
-            @RequestBody AnswerUpdateRequest request
+            @Valid @RequestBody AnswerUpdateRequest request
     ) {
         Answer updatedAnswer = questionService.updateAnswer(answerId, request.content());
         AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -9,6 +9,7 @@ import com.devoops.dto.response.AnswerUpdateResponse;
 import com.devoops.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,5 +41,14 @@ public class QuestionController {
         Answer updatedAnswer = questionService.updateAnswer(answerId, request.content());
         AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/api/questions/answer/{answerId}")
+    public ResponseEntity<Void> updateAnswer(
+            @AuthUser User user,
+            @PathVariable(name = "answerId") long answerId
+    ) {
+        questionService.deleteAnswer(answerId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/dto/request/AnswerPutRequest.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/request/AnswerPutRequest.java
@@ -1,0 +1,9 @@
+package com.devoops.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnswerPutRequest (
+        long answerId,
+        @NotBlank String content
+) {
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/request/AnswerPutRequests.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/request/AnswerPutRequests.java
@@ -1,0 +1,10 @@
+package com.devoops.dto.request;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+public record AnswerPutRequests(
+        @Valid List<AnswerPutRequest> answers
+) {
+
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/request/AnswerUpdateRequest.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/request/AnswerUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.devoops.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnswerUpdateRequest(
+        @NotBlank String content
+) {
+
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/AnswerPutResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/AnswerPutResponse.java
@@ -1,0 +1,13 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.github.Answer;
+
+public record AnswerPutResponse(
+        long answerId,
+        String content
+) {
+
+    public AnswerPutResponse(Answer answer) {
+        this(answer.getId(), answer.getContent());
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/AnswerPutResponses.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/AnswerPutResponses.java
@@ -1,0 +1,16 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.github.Answers;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AnswerPutResponses(
+        List<AnswerPutResponse> answers
+) {
+
+    public static AnswerPutResponses from(Answers answers) {
+        return answers.getValues().stream()
+                .map(AnswerPutResponse::new)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), AnswerPutResponses::new));
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/AnswerSaveResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/AnswerSaveResponse.java
@@ -1,0 +1,12 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.github.Answer;
+
+public record AnswerSaveResponse(
+        long id
+) {
+
+    public AnswerSaveResponse(Answer answer){
+        this(answer.getId());
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/AnswerUpdateResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/AnswerUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.github.Answer;
+import jakarta.validation.constraints.NotBlank;
+
+public record AnswerUpdateResponse(
+        long id,
+        @NotBlank String content
+) {
+
+    public AnswerUpdateResponse(Answer answer) {
+        this(answer.getId(), answer.getContent());
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/gss-api-app/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     //4XX
-    REPOSITIORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "레포지토리를 찾을 수 없습니다"),
+    REPOSITORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "레포지토리를 찾을 수 없습니다"),
 
     FIELD_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
     URL_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -1,7 +1,10 @@
 package com.devoops.service.question;
 
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,7 +12,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class QuestionService {
 
+    private final QuestionDomainRepository questionRepository;
+    private final AnswerDomainRepository answerRepository;
+
     public Answer saveAnswer(long questionId, User user) {
-        return null;
+        Question question = questionRepository.findByIdAndUserId(questionId, user.getId());
+        return answerRepository.save(Answer.initialize(question.getId()));
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -23,4 +23,8 @@ public class QuestionService {
     public Answer updateAnswer(long answerId, String updateContent) {
         return answerRepository.updateById(answerId, updateContent);
     }
+
+    public void deleteAnswer(long answerId) {
+        answerRepository.deleteById(answerId);
+    }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -1,10 +1,15 @@
 package com.devoops.service.question;
 
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Answers;
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.user.User;
 import com.devoops.domain.repository.github.AnswerDomainRepository;
 import com.devoops.domain.repository.github.QuestionDomainRepository;
+import com.devoops.dto.request.AnswerPutRequest;
+import com.devoops.dto.request.AnswerPutRequests;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +27,16 @@ public class QuestionService {
 
     public Answer updateAnswer(long answerId, String updateContent) {
         return answerRepository.updateById(answerId, updateContent);
+    }
+
+    public Answers updateAllAnswers(AnswerPutRequests updateRequests) {
+        List<Answer> answers = new ArrayList<>();
+        //TODO 쿼리 반복호출 말고, batch 쿼리로 줄이기
+        for(AnswerPutRequest request : updateRequests.answers()) {
+            Answer uppdatedAnswer = answerRepository.updateById(request.answerId(), request.content());
+            answers.add(uppdatedAnswer);
+        }
+        return new Answers(answers);
     }
 
     public void deleteAnswer(long answerId) {

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -1,0 +1,15 @@
+package com.devoops.service.question;
+
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    public Answer saveAnswer(long questionId, User user) {
+        return null;
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -15,8 +15,8 @@ public class QuestionService {
     private final QuestionDomainRepository questionRepository;
     private final AnswerDomainRepository answerRepository;
 
-    public Answer saveAnswer(long questionId, User user) {
-        Question question = questionRepository.findByIdAndUserId(questionId, user.getId());
+    public Answer initializeAnswer(long questionId, User user) {
+        Question question = questionRepository.findById(questionId); //소유권 검증 추가
         return answerRepository.save(Answer.initialize(question.getId()));
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/question/QuestionService.java
@@ -19,4 +19,8 @@ public class QuestionService {
         Question question = questionRepository.findById(questionId); //소유권 검증 추가
         return answerRepository.save(Answer.initialize(question.getId()));
     }
+
+    public Answer updateAnswer(long answerId, String updateContent) {
+        return answerRepository.updateById(answerId, updateContent);
+    }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -23,7 +23,7 @@ public class RepositoryService {
 
     private void validateOwn(User user, long repositoryId) {
         if(!repoRepository.existsByIdAndUserId(repositoryId, user.getId())) {
-            throw new GssException(ErrorCode.REPOSITIORY_NOT_FOUND);
+            throw new GssException(ErrorCode.REPOSITORY_NOT_FOUND);
         }
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
@@ -1,6 +1,7 @@
 package com.devoops;
 
 import com.devoops.config.TestConfig;
+import com.devoops.generator.AnswerGenerator;
 import com.devoops.generator.GithubRepoGenerator;
 import com.devoops.generator.PullRequestGenerator;
 import com.devoops.generator.QuestionGenerator;
@@ -29,5 +30,7 @@ public abstract class BaseServiceTest {
     @Autowired
     protected QuestionGenerator questionGenerator;
 
+    @Autowired
+    protected AnswerGenerator answerGenerator;
 }
 

--- a/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
@@ -3,6 +3,7 @@ package com.devoops;
 import com.devoops.config.TestConfig;
 import com.devoops.generator.GithubRepoGenerator;
 import com.devoops.generator.PullRequestGenerator;
+import com.devoops.generator.QuestionGenerator;
 import com.devoops.generator.UserGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,9 @@ public abstract class BaseServiceTest {
 
     @Autowired
     protected PullRequestGenerator pullRequestGenerator;
+
+    @Autowired
+    protected QuestionGenerator questionGenerator;
 
 }
 

--- a/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
@@ -39,4 +39,24 @@ class QuestionServiceTest extends BaseServiceTest {
         }
     }
 
+    @Nested
+    class UpdateAnswer {
+
+        @Test
+        void 질문에_대한_응답을_업데이트한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question = questionGenerator.generate(pullRequest, "질문 : 이거 왜 이렇게 했어요?");
+            Answer answer = answerGenerator.generate(question, "before");
+
+            Answer updatedAnswer = questionService.updateAnswer(answer.getId(), "after");
+
+            assertAll(
+                    () -> assertThat(updatedAnswer.getQuestionId()).isEqualTo(question.getId()),
+                    () -> assertThat(updatedAnswer.getContent()).isEqualTo("after")
+            );
+        }
+    }
+
 }

--- a/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
@@ -10,6 +10,7 @@ import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
+import com.devoops.jpa.repository.github.AnswerJpaRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,8 +21,11 @@ class QuestionServiceTest extends BaseServiceTest {
     @Autowired
     private QuestionService questionService;
 
+    @Autowired
+    private AnswerJpaRepository answerJpaRepository;
+
     @Nested
-    class InitializeAnswer {
+    class AnswerCRUD {
 
         @Test
         void 질문에_대한_최초_응답을_저장한다() {
@@ -37,10 +41,6 @@ class QuestionServiceTest extends BaseServiceTest {
                     () -> assertThat(answer.getContent()).isEqualTo("")
             );
         }
-    }
-
-    @Nested
-    class UpdateAnswer {
 
         @Test
         void 질문에_대한_응답을_업데이트한다() {

--- a/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
@@ -5,13 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Answers;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
+import com.devoops.dto.request.AnswerPutRequest;
+import com.devoops.dto.request.AnswerPutRequests;
 import com.devoops.jpa.repository.github.AnswerJpaRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +61,33 @@ class QuestionServiceTest extends BaseServiceTest {
                     () -> assertThat(updatedAnswer.getContent()).isEqualTo("after")
             );
         }
-    }
 
+        @Test
+        void 질문에_대한_다수_응답을_업데이트한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pullRequest, "질문1");
+            Question question2 = questionGenerator.generate(pullRequest, "질문1");
+            Question question3 = questionGenerator.generate(pullRequest, "질문1");
+            Answer answer1 = answerGenerator.generate(question1, "before1");
+            Answer answer2 = answerGenerator.generate(question2, "before2");
+            Answer answer3 = answerGenerator.generate(question3, "before3");
+            AnswerPutRequests answerPutRequests = new AnswerPutRequests(
+                    List.of(
+                            new AnswerPutRequest(answer1.getId(), "after1"),
+                            new AnswerPutRequest(answer2.getId(), "after2"),
+                            new AnswerPutRequest(answer3.getId(), "after3")
+                    )
+            );
+
+            List<Answer> updatedAllAnswers = questionService.updateAllAnswers(answerPutRequests).getValues();
+
+            assertAll(
+                    () -> assertThat(updatedAllAnswers.get(0).getContent()).isEqualTo("after1"),
+                    () -> assertThat(updatedAllAnswers.get(1).getContent()).isEqualTo("after2"),
+                    () -> assertThat(updatedAllAnswers.get(2).getContent()).isEqualTo("after3")
+            );
+        }
+    }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
@@ -1,0 +1,42 @@
+package com.devoops.service.question;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.devoops.BaseServiceTest;
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.entity.github.RecordStatus;
+import com.devoops.domain.entity.user.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class QuestionServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private QuestionService questionService;
+
+    @Nested
+    class InitializeAnswer {
+
+        @Test
+        void 질문에_대한_최초_응답을_저장한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question = questionGenerator.generate(pullRequest, "질문 : 이거 왜 이렇게 했어요?");
+
+            Answer answer = questionService.initializeAnswer(question.getId(), user);
+
+            assertAll(
+                    () -> assertThat(answer.getQuestionId()).isEqualTo(question.getId()),
+                    () -> assertThat(answer.getContent()).isEqualTo("")
+            );
+        }
+    }
+
+}

--- a/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
@@ -87,7 +87,7 @@ class RepositoryServiceTest extends BaseServiceTest {
 
             assertThatThrownBy(() -> repositoryService.getPullRequestsByRepository(seonwoo, repo.getId(), 6, 0))
                     .isInstanceOf(GssException.class)
-                    .hasMessage(ErrorCode.REPOSITIORY_NOT_FOUND.getMessage());
+                    .hasMessage(ErrorCode.REPOSITORY_NOT_FOUND.getMessage());
         }
 
 

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/Answer.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/Answer.java
@@ -7,7 +7,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Answer {
 
+    private static final String INITIALIZED_ANSWER_CONTENT = "";
+
     private final Long id;
     private final long questionId;
     private final String content;
+
+    public static Answer initialize(long questionId) {
+        return new Answer(null, questionId, INITIALIZED_ANSWER_CONTENT);
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/Answer.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/Answer.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Answer {
 
+    private final Long id;
     private final long questionId;
     private final String content;
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/Answers.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/Answers.java
@@ -1,0 +1,12 @@
+package com.devoops.domain.entity.github;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Answers {
+
+    private final List<Answer> values;
+}

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/Question.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/Question.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Question {
 
+    private final Long id;
     private final long pullRequestId;
     private final String content;
     private final boolean isAnswered;

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
@@ -1,4 +1,8 @@
 package com.devoops.domain.repository.github;
 
+import com.devoops.domain.entity.github.Answer;
+
 public interface AnswerDomainRepository {
+
+    Answer save(Answer answer);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
@@ -7,4 +7,6 @@ public interface AnswerDomainRepository {
     Answer save(Answer answer);
 
     Answer updateById(long answerId, String content);
+
+    void deleteById(long answerId);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
@@ -5,4 +5,6 @@ import com.devoops.domain.entity.github.Answer;
 public interface AnswerDomainRepository {
 
     Answer save(Answer answer);
+
+    Answer updateById(long answerId, String content);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
@@ -4,7 +4,7 @@ import com.devoops.domain.entity.github.Question;
 
 public interface QuestionDomainRepository {
 
-    Question findByIdAndUserId(long questionId, long userId);
+    Question findById(long questionId);
 
     Question save(Question question);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
@@ -1,5 +1,8 @@
 package com.devoops.domain.repository.github;
 
+import com.devoops.domain.entity.github.Question;
+
 public interface QuestionDomainRepository {
 
+    Question findByIdAndUserId(long questionId, long userId);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
@@ -5,4 +5,6 @@ import com.devoops.domain.entity.github.Question;
 public interface QuestionDomainRepository {
 
     Question findByIdAndUserId(long questionId, long userId);
+
+    Question save(Question question);
 }

--- a/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
+++ b/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum RepositoryErrorCode {
 
     GITHUB_REPOSITORY_NOT_FOUND("찾는 레포지토리가 존재하지 않습니다"),
+    PULL_REQUEST_NOT_FOUND("찾는 풀 리퀘스트가 존재하지 않습니다"),
     QUESTION_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
     ;
 

--- a/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
+++ b/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum RepositoryErrorCode {
 
     GITHUB_REPOSITORY_NOT_FOUND("찾는 레포지토리가 존재하지 않습니다"),
+    QUESTION_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
     ;
 
     private final String message;

--- a/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
+++ b/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
@@ -8,6 +8,8 @@ public enum RepositoryErrorCode {
     GITHUB_REPOSITORY_NOT_FOUND("찾는 레포지토리가 존재하지 않습니다"),
     PULL_REQUEST_NOT_FOUND("찾는 풀 리퀘스트가 존재하지 않습니다"),
     QUESTION_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
+    ANSWER_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
+    USER_NOT_FOUND("찾는 회원이 존재하지 않습니다"),
     ;
 
     private final String message;

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
@@ -48,14 +48,9 @@ public class AnswerEntity extends BaseTimeEntity {
         return new AnswerEntity(
                 answer.getId(),
                 question,
-                answer.getContent()
+                answer.getContent(),
+                LocalDateTime.now()
         );
-    }
-
-    public AnswerEntity(Long id, QuestionEntity question, String content) {
-        this.id = id;
-        this.question = question;
-        this.content = content;
     }
 
     public Answer toDomainEntity() {

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
@@ -53,6 +53,10 @@ public class AnswerEntity extends BaseTimeEntity {
         );
     }
 
+    public void update(String content) {
+        this.content = content;
+    }
+
     public Answer toDomainEntity() {
         return new Answer(
                 this.id,

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerEntity.java
@@ -44,8 +44,23 @@ public class AnswerEntity extends BaseTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public static AnswerEntity from(Answer answer, QuestionEntity question) {
+        return new AnswerEntity(
+                answer.getId(),
+                question,
+                answer.getContent()
+        );
+    }
+
+    public AnswerEntity(Long id, QuestionEntity question, String content) {
+        this.id = id;
+        this.question = question;
+        this.content = content;
+    }
+
     public Answer toDomainEntity() {
         return new Answer(
+                this.id,
                 question.getId(),
                 content
         );

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/QuestionEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/QuestionEntity.java
@@ -42,6 +42,7 @@ public class QuestionEntity extends BaseTimeEntity {
 
     public Question toDomainEntity() {
         return new Question(
+                this.id,
                 pullRequest.getId(),
                 this.content,
                 this.isAnswered

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/QuestionEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/QuestionEntity.java
@@ -40,6 +40,10 @@ public class QuestionEntity extends BaseTimeEntity {
 
     private boolean isAnswered;
 
+    public static QuestionEntity from(Question question, PullRequestEntity pullRequest) {
+        return new QuestionEntity(question.getId(), pullRequest, question.getContent(), question.isAnswered());
+    }
+
     public Question toDomainEntity() {
         return new Question(
                 this.id,

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -36,4 +36,10 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
         answerEntity.update(content);
         return answerEntity.toDomainEntity();
     }
+
+    @Override
+    @Transactional
+    public void deleteById(long answerId){
+        answerJpaRepository.deleteById(answerId);
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -30,8 +30,8 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
 
     @Override
     @Transactional
-    public Answer updateByQuestionId(long questionId, String content) {
-        AnswerEntity answerEntity = answerJpaRepository.findByQuestionId(questionId)
+    public Answer updateById(long answerId, String content) {
+        AnswerEntity answerEntity = answerJpaRepository.findById(answerId)
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.ANSWER_NOT_FOUND));
         answerEntity.update(content);
         return answerEntity.toDomainEntity();

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -1,6 +1,12 @@
 package com.devoops.jpa.repository.github;
 
+import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.repository.github.AnswerDomainRepository;
+import com.devoops.exception.GssRepositoryException;
+import com.devoops.exception.RepositoryErrorCode;
+import com.devoops.jpa.entity.github.AnswerEntity;
+import com.devoops.jpa.entity.github.QuestionEntity;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +15,14 @@ import org.springframework.stereotype.Repository;
 public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
 
     private final AnswerJpaRepository answerJpaRepository;
+    private final QuestionJpaRepository questionJpaRepository;
+
+    @Override
+    public Answer save(Answer answer) {
+        QuestionEntity question = questionJpaRepository.findById(answer.getQuestionId())
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
+        AnswerEntity answerEntity = AnswerEntity.from(answer, question);
+        AnswerEntity savedAnswer = answerJpaRepository.save(answerEntity);
+        return savedAnswer.toDomainEntity();
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.devoops.jpa.entity.github.QuestionEntity;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,11 +19,21 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
     private final QuestionJpaRepository questionJpaRepository;
 
     @Override
+    @Transactional
     public Answer save(Answer answer) {
         QuestionEntity question = questionJpaRepository.findById(answer.getQuestionId())
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
         AnswerEntity answerEntity = AnswerEntity.from(answer, question);
         AnswerEntity savedAnswer = answerJpaRepository.save(answerEntity);
         return savedAnswer.toDomainEntity();
+    }
+
+    @Override
+    @Transactional
+    public Answer updateByQuestionId(long questionId, String content) {
+        AnswerEntity answerEntity = answerJpaRepository.findByQuestionId(questionId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.ANSWER_NOT_FOUND));
+        answerEntity.update(content);
+        return answerEntity.toDomainEntity();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.AnswerEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
@@ -1,7 +1,6 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.AnswerEntity;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.devoops.jpa.repository.user.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.ietf.jgss.GSSException;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepositor
     private final GithubRepoJpaRepository repoJpaRepository;
 
     @Override
+    @Transactional
     public GithubRepository save(GithubRepository githubRepository) {
         UserEntity userEntity = userJpaRepository.findById(githubRepository.getUserId()).get();
         GithubRepositoryEntity repositoryEntity = GithubRepositoryEntity.from(githubRepository, userEntity);
@@ -25,6 +27,7 @@ public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepositor
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean existsByIdAndUserId(long id, long userId) {
         return repoJpaRepository.existsByIdAndUser_Id(id, userId);
     }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubTokenDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubTokenDomainRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.devoops.jpa.repository.github;
 import com.devoops.domain.entity.github.GithubToken;
 import com.devoops.domain.entity.user.User;
 import com.devoops.domain.repository.github.GithubTokenDomainRepository;
+import com.devoops.exception.GssRepositoryException;
+import com.devoops.exception.RepositoryErrorCode;
 import com.devoops.jpa.entity.github.GithubTokenEntity;
 import com.devoops.jpa.entity.user.UserEntity;
 import com.devoops.jpa.repository.user.UserJpaRepository;
@@ -17,11 +19,11 @@ public class GithubTokenDomainRepositoryImpl implements GithubTokenDomainReposit
     private final GithubTokenJpaRepository githubTokenJpaRepository;
     private final UserJpaRepository userJpaRepository;
 
-    @Transactional
-    @Override
-    public GithubToken save(GithubToken token, User owner) {
+     @Override
+     @Transactional
+     public GithubToken save(GithubToken token, User owner) {
         UserEntity userEntity = userJpaRepository.findById(owner.getId())
-                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다")); //TODO 커스텀 에러 전환)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.USER_NOT_FOUND));
 
         return githubTokenJpaRepository.save(GithubTokenEntity.from(userEntity, token))
                 .toDomainEntity();

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
     private final GithubRepoJpaRepository githubRepoRepository;
 
     @Override
+    @Transactional
     public PullRequest save(PullRequest pullRequest) {
         GithubRepositoryEntity githubRepositoryEntity = githubRepoRepository.findById(pullRequest.getRepositoryId())
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.GITHUB_REPOSITORY_NOT_FOUND));
@@ -31,6 +33,7 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PullRequests findPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "mergedAt"));
         return pullRequestRepository.findByRepositoryId(repositoryId, pageable)

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.PullRequestEntity;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.devoops.jpa.entity.github.PullRequestEntity;
 import com.devoops.jpa.entity.github.QuestionEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,17 +17,19 @@ public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
     private final QuestionJpaRepository questionRepository;
     private final PullRequestJpaRepository pullRequestRepository;
 
-    public Question findById(long questionId) {
-        QuestionEntity questionEntity = questionRepository.findById(questionId)
-                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
-        return questionEntity.toDomainEntity();
-    }
-
+    @Transactional
     public Question save(Question question) {
         PullRequestEntity pullRequest = pullRequestRepository.findById(question.getPullRequestId())
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.PULL_REQUEST_NOT_FOUND));
         QuestionEntity questionEntity = QuestionEntity.from(question, pullRequest);
         QuestionEntity savedQuestion = questionRepository.save(questionEntity);
         return savedQuestion.toDomainEntity();
+    }
+
+    @Transactional(readOnly = true)
+    public Question findById(long questionId) {
+        QuestionEntity questionEntity = questionRepository.findById(questionId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
+        return questionEntity.toDomainEntity();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.devoops.jpa.repository.github;
 
+import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.repository.github.QuestionDomainRepository;
+import com.devoops.jpa.entity.github.QuestionEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,9 @@ import org.springframework.stereotype.Repository;
 public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
 
     private final QuestionJpaRepository questionRepository;
+
+    public Question findByIdAndUserId(long questionId, long userId) {
+        QuestionEntity questionEntity = questionRepository.findByIdAndUser_Id(questionId, userId);
+        return questionEntity.toDomainEntity();
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
@@ -16,8 +16,9 @@ public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
     private final QuestionJpaRepository questionRepository;
     private final PullRequestJpaRepository pullRequestRepository;
 
-    public Question findByIdAndUserId(long questionId, long userId) {
-        QuestionEntity questionEntity = questionRepository.findByIdAndUser_Id(questionId, userId);
+    public Question findById(long questionId) {
+        QuestionEntity questionEntity = questionRepository.findById(questionId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
         return questionEntity.toDomainEntity();
     }
 

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
@@ -2,6 +2,9 @@ package com.devoops.jpa.repository.github;
 
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.repository.github.QuestionDomainRepository;
+import com.devoops.exception.GssRepositoryException;
+import com.devoops.exception.RepositoryErrorCode;
+import com.devoops.jpa.entity.github.PullRequestEntity;
 import com.devoops.jpa.entity.github.QuestionEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,9 +14,18 @@ import org.springframework.stereotype.Repository;
 public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
 
     private final QuestionJpaRepository questionRepository;
+    private final PullRequestJpaRepository pullRequestRepository;
 
     public Question findByIdAndUserId(long questionId, long userId) {
         QuestionEntity questionEntity = questionRepository.findByIdAndUser_Id(questionId, userId);
         return questionEntity.toDomainEntity();
+    }
+
+    public Question save(Question question) {
+        PullRequestEntity pullRequest = pullRequestRepository.findById(question.getPullRequestId())
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.PULL_REQUEST_NOT_FOUND));
+        QuestionEntity questionEntity = QuestionEntity.from(question, pullRequest);
+        QuestionEntity savedQuestion = questionRepository.save(questionEntity);
+        return savedQuestion.toDomainEntity();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
@@ -1,8 +1,12 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.QuestionEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Integer> {
 
+    QuestionEntity findByIdAndUser_Id(long questionId, long userId);
+
+    Optional<QuestionEntity> findById(long id);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
@@ -3,10 +3,9 @@ package com.devoops.jpa.repository.github;
 import com.devoops.jpa.entity.github.QuestionEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Integer> {
-
-    QuestionEntity findByIdAndUser_Id(long questionId, long userId);
 
     Optional<QuestionEntity> findById(long id);
 }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/AnswerGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/AnswerGenerator.java
@@ -1,0 +1,19 @@
+package com.devoops.generator;
+
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnswerGenerator {
+
+    @Autowired
+    private AnswerDomainRepository answerDomainRepository;
+
+    public Answer generate(Question question, String content) {
+        Answer answer = new Answer(null, question.getId(), content);
+        return answerDomainRepository.save(answer);
+    }
+}

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/QuestionGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/QuestionGenerator.java
@@ -1,0 +1,19 @@
+package com.devoops.generator;
+
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuestionGenerator {
+
+    @Autowired
+    private QuestionDomainRepository questionDomainRepository;
+
+    public Question generate(PullRequest pullRequest, String content) {
+        Question question = new Question(null, pullRequest.getId(), content, false);
+        return questionDomainRepository.save(question);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-81

# 🔂 변경 내역
회고에 대한 CRUD api를 구현합니다

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 질문에 대한 답변 생성, 수정(단일/일괄), 삭제를 지원하는 REST API가 추가되었습니다.
  * 답변 관련 요청 및 응답을 위한 데이터 전송 객체(DTO)가 도입되었습니다.

* **버그 수정**
  * 일부 오류 코드의 오타가 수정되었습니다.

* **테스트**
  * 질문-답변 기능에 대한 서비스 테스트가 추가되었습니다.
  * 테스트 코드에서 답변/질문 생성 유틸리티가 도입되었습니다.

* **기타**
  * 도메인 및 저장소 계층에 질문/답변 관련 엔티티와 CRUD 기능이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->