### PR TITLE
Fix/openapi version

### DIFF
--- a/gss-api-app/build.gradle
+++ b/gss-api-app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 
     //Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/gss-api-app/src/main/java/com/devoops/exception/handler/GlobalExceptionHandler.java
+++ b/gss-api-app/src/main/java/com/devoops/exception/handler/GlobalExceptionHandler.java
@@ -9,7 +9,6 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -26,61 +25,70 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ErrorResponse> handleBindingException(BindException exception) {
+        log.warn("Binding exception occurred", exception);
         return toResponse(ErrorCode.FIELD_ERROR);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException exception) {
+        log.warn("Constraint violation occurred", exception);
         return toResponse(ErrorCode.URL_PARAMETER_ERROR);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-            MethodArgumentTypeMismatchException exception) {
+        MethodArgumentTypeMismatchException exception) {
+        log.warn("Method argument type mismatch", exception);
         return toResponse(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
     }
 
     @ExceptionHandler(ClientAbortException.class)
     public ResponseEntity<ErrorResponse> handleClientAbortException(ClientAbortException exception) {
+        log.info("Client aborted the request", exception);
         return toResponse(ErrorCode.ALREADY_DISCONNECTED);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
-            HttpRequestMethodNotSupportedException exception
-    ) {
+        HttpRequestMethodNotSupportedException exception) {
+        log.warn("HTTP method not supported", exception);
         return toResponse(ErrorCode.METHOD_NOT_SUPPORTED);
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
-            HttpMediaTypeNotSupportedException exception
-    ) {
+        HttpMediaTypeNotSupportedException exception) {
+        log.warn("Unsupported media type", exception);
         return toResponse(ErrorCode.MEDIA_TYPE_NOT_SUPPORTED);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException exception) {
+        log.warn("No resource found", exception);
         return toResponse(ErrorCode.NO_RESOURCE_FOUND);
     }
 
     @ExceptionHandler(GssException.class)
     public ResponseEntity<ErrorResponse> handleGssException(GssException exception) {
+        log.error("Custom GssException occurred: {}", exception.getMessage(), exception);
         return toResponse(exception.getErrorCode());
     }
 
     @ExceptionHandler(GssRepositoryException.class)
     public ResponseEntity<ErrorResponse> handleGssRepositoryException(GssRepositoryException exception) {
+        log.error("GssRepositoryException occurred", exception);
         return toResponse(ErrorCode.INTERNAL_SERVER_ERROR);
     }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.error("Unhandled exception occurred", exception);
         return toResponse(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     private ResponseEntity<ErrorResponse> toResponse(ErrorCode errorCode) {
         ErrorResponse errorResponse = new ErrorResponse(errorCode);
         return ResponseEntity.status(errorCode.getStatus())
-                .body(errorResponse);
+            .body(errorResponse);
     }
 }

--- a/gss-mcp-app/build.gradle
+++ b/gss-mcp-app/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     //Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:


# 🔂 변경 내역
- 문서 엔드포인트 접근시에 발생하는 `java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'` 대응
- Spring Boot 3.4 과 springdoc-openapi 호환성 맞춤
FYI;[compatibility matrix of springdoc-openapi with spring-boot](https://springdoc.org/faq.html#_what_is_the_compatibility_matrix_of_springdoc_openapi_with_spring_boot)

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 예외 처리 시 로깅이 추가되어 오류 발생 시 더 자세한 정보를 기록합니다.

* **기타**
  * OpenAPI UI 라이브러리 버전이 2.7.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->