### PR TITLE
feat: 레포지토리 및 pr 카운트 조회 API 추가

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
@@ -6,27 +6,28 @@ import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.request.RepositorySaveRequest;
+import com.devoops.dto.response.MyRepositoriesResponse;
 import com.devoops.dto.response.RepositoryPullRequestResponses;
 import com.devoops.dto.response.RepositorySaveResponse;
 import com.devoops.service.facade.RepositoryFacadeService;
+import com.devoops.service.repository.RepositoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/repositories")
 public class RepositoryController implements RepositoryControllerSwagger {
 
     private final RepositoryFacadeService repositoryFacadeService;
+    private final RepositoryService repositoryService;
 
-    @GetMapping("/api/repositories/{repositoryId}/pull-requests")
+    @GetMapping("/{repositoryId}/pull-requests")
     public ResponseEntity<RepositoryPullRequestResponses> getRepositoryPullRequests(
             @AuthUser User user,
             @PathVariable(name = "repositoryId") long repositoryId,
@@ -38,7 +39,7 @@ public class RepositoryController implements RepositoryControllerSwagger {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/api/repositories")
+    @PostMapping
     public ResponseEntity<RepositorySaveResponse> saveRepository(
             @AuthUser User user,
             @Valid @RequestBody RepositorySaveRequest request
@@ -47,6 +48,12 @@ public class RepositoryController implements RepositoryControllerSwagger {
         RepositorySaveResponse response = new RepositorySaveResponse(savedRepository);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MyRepositoriesResponse> getMyRepositories(@AuthUser User user) {
+        List<GithubRepository> repositories = repositoryService.getMyRepositories(user);
+        return ResponseEntity.ok(MyRepositoriesResponse.from(repositories));
     }
 }
 

--- a/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
@@ -1,0 +1,31 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.github.GithubRepository;
+
+import java.util.List;
+
+public record MyRepositoriesResponse(
+    List<RepositorySummary> repositories
+) {
+    public static MyRepositoriesResponse from(List<GithubRepository> repositories) {
+        return new MyRepositoriesResponse(
+            repositories.stream()
+                .map(RepositorySummary::from)
+                .toList()
+        );
+    }
+
+    public record RepositorySummary(
+        long id,
+        String name,
+        int pullRequestCount
+    ) {
+        public static RepositorySummary from(GithubRepository repository) {
+            return new RepositorySummary(
+                repository.getId(),
+                repository.getName(),
+                repository.getPrCount()
+            );
+        }
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -12,6 +12,8 @@ import com.devoops.service.repository.RepositoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import static com.devoops.Constants.INITIAL_PULL_REQUEST_COUNT;
+
 @Service
 @RequiredArgsConstructor
 public class RepositoryFacadeService {
@@ -29,11 +31,12 @@ public class RepositoryFacadeService {
     private GithubRepository saveRepository(GithubRepoUrl url, User user) {
         GithubRepoInfoResponse repositoryInfo = gitHubService.getRepositoryInfo(url, user.getGithubToken());
         RepositoryCreateCommand createCommand = new RepositoryCreateCommand(
-                user.getId(),
-                repositoryInfo.name(),
-                repositoryInfo.url(),
-                repositoryInfo.getOwnerName(),
-                repositoryInfo.id()
+            user.getId(),
+            repositoryInfo.name(),
+            repositoryInfo.url(),
+            repositoryInfo.getOwnerName(),
+            INITIAL_PULL_REQUEST_COUNT,
+            repositoryInfo.id()
         );
         return repositoryService.save(createCommand);
     }

--- a/gss-api-app/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -11,6 +11,8 @@ import com.devoops.exception.errorcode.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class RepositoryService {
@@ -28,8 +30,12 @@ public class RepositoryService {
     }
 
     private void validateOwn(User user, long repositoryId) {
-        if(!repoRepository.existsByIdAndUserId(repositoryId, user.getId())) {
+        if (!repoRepository.existsByIdAndUserId(repositoryId, user.getId())) {
             throw new GssException(ErrorCode.REPOSITORY_NOT_FOUND);
         }
+    }
+
+    public List<GithubRepository> getMyRepositories(User user) {
+        return repoRepository.findByUserId(user.getId());
     }
 }

--- a/gss-common/src/main/java/com/devoops/Constants.java
+++ b/gss-common/src/main/java/com/devoops/Constants.java
@@ -1,0 +1,6 @@
+package com.devoops;
+
+public final class Constants {
+    public static final int INITIAL_PULL_REQUEST_COUNT = 0;
+    
+}

--- a/gss-domain/build.gradle
+++ b/gss-domain/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
 	implementation project(":gss-infra:gss-secretmanager")
+	implementation project(":gss-common")
 
 	//valid
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/gss-domain/src/main/java/com/devoops/command/request/RepositoryCreateCommand.java
+++ b/gss-domain/src/main/java/com/devoops/command/request/RepositoryCreateCommand.java
@@ -7,10 +7,11 @@ public record RepositoryCreateCommand(
         String repositoryName,
         String url,
         String ownerName,
+        int prCount,
         long externalId
 ) {
 
     public GithubRepository toDomainEntity() {
-        return new GithubRepository(userId, repositoryName, url, ownerName, externalId);
+        return new GithubRepository(userId, repositoryName, url, ownerName, prCount, externalId);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
@@ -15,7 +15,7 @@ public class GithubRepository {
     private final int prCount;
     private final long externalId;
 
-    public GithubRepository(long userId, String name, String url, String owner, long externalId) {
-        this(null, userId, name, url, owner, externalId);
+    public GithubRepository(long userId, String name, String url, String owner, int prCount, long externalId) {
+        this(null, userId, name, url, owner, prCount, externalId);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
@@ -12,6 +12,7 @@ public class GithubRepository {
     private final String name;
     private final String url;
     private final String owner;
+    private final int prCount;
     private final long externalId;
 
     public GithubRepository(long userId, String name, String url, String owner, long externalId) {

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
@@ -1,8 +1,9 @@
 package com.devoops.domain.entity.github;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
@@ -2,6 +2,8 @@ package com.devoops.domain.repository.github;
 
 import com.devoops.domain.entity.github.GithubRepository;
 
+import java.util.List;
+
 public interface GithubRepoDomainRepository {
 
     GithubRepository save(GithubRepository githubRepository);
@@ -9,4 +11,6 @@ public interface GithubRepoDomainRepository {
     boolean existsByIdAndUserId(long id, long userId);
 
     GithubRepository findByIdAndUserId(long id, long userId);
+
+    List<GithubRepository> findByUserId(long userId);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -43,28 +43,34 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     @NotNull
     private String owner;
 
+    @NotNull
+    private int pullRequestCount;
+
     private long githubRepositoryId;
 
     public static GithubRepositoryEntity from(GithubRepository githubRepository, UserEntity user) {
+        final int INITIAL_PULL_REQUEST_COUNT = 0;
+
         return new GithubRepositoryEntity(
-                githubRepository.getId(),
-                user,
-                githubRepository.getName(),
-                githubRepository.getUrl(),
-                githubRepository.getName(),
-                githubRepository.getExternalId()
+            githubRepository.getId(),
+            user,
+            githubRepository.getName(),
+            githubRepository.getUrl(),
+            githubRepository.getName(),
+            INITIAL_PULL_REQUEST_COUNT,
+            githubRepository.getExternalId()
         );
     }
 
-
     public GithubRepository toDomainEntity() {
         return new GithubRepository(
-                this.id,
-                this.user.getId(),
-                this.name,
-                this.url,
-                this.owner,
-                this.githubRepositoryId
+            this.id,
+            this.user.getId(),
+            this.name,
+            this.url,
+            this.owner,
+            this.pullRequestCount,
+            this.githubRepositoryId
         );
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -43,7 +43,6 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     @NotNull
     private String owner;
 
-    @NotNull
     private int pullRequestCount;
 
     private long githubRepositoryId;

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -19,6 +19,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.devoops.Constants.INITIAL_PULL_REQUEST_COUNT;
+
 @Entity
 @Getter
 @Table(name = "repositories")
@@ -48,7 +50,6 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     private long githubRepositoryId;
 
     public static GithubRepositoryEntity from(GithubRepository githubRepository, UserEntity user) {
-        final int INITIAL_PULL_REQUEST_COUNT = 0;
 
         return new GithubRepositoryEntity(
             githubRepository.getId(),

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -3,23 +3,12 @@ package com.devoops.jpa.entity.github;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.jpa.entity.BaseTimeEntity;
 import com.devoops.jpa.entity.user.UserEntity;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static com.devoops.Constants.INITIAL_PULL_REQUEST_COUNT;
 
 @Entity
 @Getter
@@ -57,7 +46,7 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
             githubRepository.getName(),
             githubRepository.getUrl(),
             githubRepository.getName(),
-            INITIAL_PULL_REQUEST_COUNT,
+            githubRepository.getPrCount(),
             githubRepository.getExternalId()
         );
     }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepository {
@@ -40,5 +42,14 @@ public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepositor
             .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.GITHUB_REPOSITORY_NOT_FOUND));
 
         return repositoryEntity.toDomainEntity();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GithubRepository> findByUserId(long userId) {
+        return repoJpaRepository.findAllByUser_Id(userId)
+            .stream()
+            .map(GithubRepositoryEntity::toDomainEntity)
+            .toList();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoJpaRepository.java
@@ -3,6 +3,7 @@ package com.devoops.jpa.repository.github;
 import com.devoops.jpa.entity.github.GithubRepositoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GithubRepoJpaRepository extends JpaRepository<GithubRepositoryEntity, Long> {
@@ -10,4 +11,6 @@ public interface GithubRepoJpaRepository extends JpaRepository<GithubRepositoryE
     boolean existsByIdAndUser_Id(Long id, Long userId);
 
     Optional<GithubRepositoryEntity> findByIdAndUser_Id(Long id, Long userId);
+
+    List<GithubRepositoryEntity> findAllByUser_Id(Long userId);
 }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/GithubRepoGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/GithubRepoGenerator.java
@@ -13,7 +13,7 @@ public class GithubRepoGenerator {
     private GithubRepoDomainRepository githubRepoDomainRepository;
 
     public GithubRepository generate(User user, String repoName) {
-        GithubRepository repository = new GithubRepository(null, user.getId(), repoName, "url", "owner", 1L);
+        GithubRepository repository = new GithubRepository(null, user.getId(), repoName, "url", "owner", 0, 1L);
         return githubRepoDomainRepository.save(repository);
     }
 }


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:


# 🔂 변경 내역
- 토큰으로 나의 레포지토리 정보 및 PR 카운트 조회 API
- [임시 API 노션 페이지](https://www.notion.so/api-repositories-me-21ebee7f5996807c9f1bd14edc389f6f?source=copy_link)

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증된 사용자의 저장소 목록을 조회하는 새로운 API 엔드포인트(`/api/repositories/me`)가 추가되었습니다.
  * 각 저장소의 풀 리퀘스트 개수가 함께 제공됩니다.

* **기능 개선**
  * 저장소별 풀 리퀘스트 목록 조회 엔드포인트의 경로가 `/api/repositories/{repositoryId}/pull-requests`에서 `/{repositoryId}/pull-requests`로 변경되었습니다.

* **버그 수정 및 기타**
  * 엔티티 및 DTO에 저장소별 풀 리퀘스트 개수 필드가 추가되어, 관련 정보가 정확히 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->