### PR TITLE
[GSS-94] 이어서 회고하기 API 개발

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
@@ -2,6 +2,7 @@ package com.devoops.controller.pullrequests;
 
 import com.devoops.controller.auth.AuthUser;
 import com.devoops.domain.entity.user.User;
+import com.devoops.dto.response.PullRequestRankingResponses;
 import com.devoops.dto.response.PullRequestReadResponse;
 import com.devoops.service.facade.PullRequestFacadeService;
 import com.devoops.service.pullrequests.PullRequestService;
@@ -25,6 +26,12 @@ public class PullRequestController {
     ) {
         PullRequestReadResponse response = pullRequestFacadeService.read(pullRequestId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/pull-requests/ranking")
+    public ResponseEntity<PullRequestRankingResponses> getPullRequestRanking(@AuthUser User user) {
+//        PullRequestReadResponse response = pullRequestFacadeService.read();
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/api/pull-requests/{pullRequestId}/done")

--- a/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
@@ -30,8 +30,8 @@ public class PullRequestController {
 
     @GetMapping("/api/pull-requests/ranking")
     public ResponseEntity<PullRequestRankingResponses> getPullRequestRanking(@AuthUser User user) {
-//        PullRequestReadResponse response = pullRequestFacadeService.read();
-        return ResponseEntity.ok().build();
+        PullRequestRankingResponses response = pullRequestFacadeService.ranking(user.getId());
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/api/pull-requests/{pullRequestId}/done")

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -9,6 +9,7 @@ import com.devoops.dto.request.AnswerUpdateRequest;
 import com.devoops.dto.response.AnswerPutResponses;
 import com.devoops.dto.response.AnswerSaveResponse;
 import com.devoops.dto.response.AnswerUpdateResponse;
+import com.devoops.service.facade.QuestionFacadeService;
 import com.devoops.service.question.QuestionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,14 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class QuestionController {
 
-    private final QuestionService questionService;
+    private final QuestionFacadeService questionFacadeService;
 
     @PostMapping("/api/questions/{questionId}/answer")
     public ResponseEntity<AnswerSaveResponse> createAnswer(
             @AuthUser User user,
             @PathVariable(name = "questionId") long questionId
     ) {
-        Answer answer = questionService.initializeAnswer(questionId, user);
+        Answer answer = questionFacadeService.initializeAnswer(questionId, user);
         AnswerSaveResponse response = new AnswerSaveResponse(answer);
         return ResponseEntity.ok(response);
     }
@@ -42,7 +43,7 @@ public class QuestionController {
             @AuthUser User user,
             @Valid @RequestBody AnswerPutRequests request
     ) {
-        Answers updatedAnswers = questionService.updateAllAnswers(request);
+        Answers updatedAnswers = questionFacadeService.updateAllAnswers(request);
         AnswerPutResponses response = AnswerPutResponses.from(updatedAnswers);
         return ResponseEntity.ok(response);
     }
@@ -53,7 +54,9 @@ public class QuestionController {
             @PathVariable(name = "answerId") long answerId,
             @Valid @RequestBody AnswerUpdateRequest request
     ) {
-        Answer updatedAnswer = questionService.updateAnswer(answerId, request.content());
+
+        //TODO ranking 갱신
+        Answer updatedAnswer = questionFacadeService.updateAnswer(answerId, request.content());
         AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);
         return ResponseEntity.ok(response);
     }
@@ -63,7 +66,7 @@ public class QuestionController {
             @AuthUser User user,
             @PathVariable(name = "answerId") long answerId
     ) {
-        questionService.deleteAnswer(answerId);
+        questionFacadeService.deleteAnswer(answerId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -10,7 +10,6 @@ import com.devoops.dto.response.AnswerPutResponses;
 import com.devoops.dto.response.AnswerSaveResponse;
 import com.devoops.dto.response.AnswerUpdateResponse;
 import com.devoops.service.facade.QuestionFacadeService;
-import com.devoops.service.question.QuestionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -56,13 +55,13 @@ public class QuestionController {
     ) {
 
         //TODO ranking 갱신
-        Answer updatedAnswer = questionFacadeService.updateAnswer(answerId, request.content());
+        Answer updatedAnswer = questionFacadeService.updateAnswer(answerId, request.content(), user.getId());
         AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/api/questions/answer/{answerId}")
-    public ResponseEntity<Void> updateAnswer(
+    public ResponseEntity<Void> deleteAnswer(
             @AuthUser User user,
             @PathVariable(name = "answerId") long answerId
     ) {

--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponse.java
@@ -1,5 +1,6 @@
 package com.devoops.dto.response;
 
+import com.devoops.domain.entity.github.AnswerRanking;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -11,4 +12,12 @@ public record PullRequestRankingResponse(
         @NotNull LocalDateTime updatedAt
 ) {
 
+    public PullRequestRankingResponse(AnswerRanking answerRanking) {
+        this(
+                answerRanking.getPullRequestId(),
+                answerRanking.getPullRequestTitle(),
+                answerRanking.getQuestionContent(),
+                answerRanking.getUpdatedAt()
+        );
+    }
 }

--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponse.java
@@ -1,0 +1,14 @@
+package com.devoops.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record PullRequestRankingResponse(
+        long pullRequestId,
+        @NotBlank String title,
+        @NotBlank String content,
+        @NotNull LocalDateTime updatedAt
+) {
+
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponses.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponses.java
@@ -1,9 +1,17 @@
 package com.devoops.dto.response;
 
+import com.devoops.domain.entity.github.AnswerRankings;
 import java.util.List;
 
 public record PullRequestRankingResponses(
         List<PullRequestRankingResponse> answerRanking
 ) {
 
+    public static PullRequestRankingResponses from(AnswerRankings answerRankings) {
+        List<PullRequestRankingResponse> responses = answerRankings.getRankings()
+                .stream()
+                .map(PullRequestRankingResponse::new)
+                .toList();
+        return new PullRequestRankingResponses(responses);
+    }
 }

--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponses.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestRankingResponses.java
@@ -1,0 +1,9 @@
+package com.devoops.dto.response;
+
+import java.util.List;
+
+public record PullRequestRankingResponses(
+        List<PullRequestRankingResponse> answerRanking
+) {
+
+}

--- a/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
@@ -27,7 +27,7 @@ public class AnswerRankingService {
 
         Optional<AnswerRanking> samePrRanking = answerRankings.getSamePrRanking(question.getPullRequestId());
         if (samePrRanking.isPresent()) {
-            answerRankingDomainRepository.update(samePrRanking.get());
+            answerRankingDomainRepository.update(samePrRanking.get().getPullRequestId(), answer.getQuestionId());
             return;
         }
         rotateAnswerRanking(answerRankings, answer, userId);

--- a/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
@@ -22,25 +22,22 @@ public class AnswerRankingService {
     }
 
     public void push(Answer answer, long userId) {
-        //유저별 랭킹 가져오기
         AnswerRankings answerRankings = findUserRanking(userId);
         Question question = questionDomainRepository.findById(answer.getQuestionId());
 
         Optional<AnswerRanking> samePrRanking = answerRankings.getSamePrRanking(question.getPullRequestId());
-        //같은 PR이 있다면 덮어쓰기
-        if(samePrRanking.isPresent()) {
-            AnswerRanking answerRanking = samePrRanking.get();
-            answerRankingDomainRepository.update(answerRanking);
+        if (samePrRanking.isPresent()) {
+            answerRankingDomainRepository.update(samePrRanking.get());
             return;
         }
+        rotateAnswerRanking(answerRankings, answer, userId);
+    }
 
-        //다 찾다면 가장 느린 것 삭제
-        if(answerRankings.isFull()) {
+    private void rotateAnswerRanking(AnswerRankings answerRankings, Answer answer, long userId) {
+        if (answerRankings.isFull()) {
             AnswerRanking lastUsedRanking = answerRankings.getLastUsedRanking();
             answerRankingDomainRepository.deleteById(lastUsedRanking.getId());
         }
-
-        //새로운 answerRanking 추가하기
         answerRankingDomainRepository.save(answer, userId);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
@@ -1,0 +1,17 @@
+package com.devoops.service.answerranking;
+
+import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerRankingService {
+
+    private final AnswerRankingDomainRepository answerRankingDomainRepository;
+
+    public AnswerRankings findUserRanking(long userId) {
+        return answerRankingDomainRepository.findAllByUserId(userId);
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/answerranking/AnswerRankingService.java
@@ -1,7 +1,12 @@
 package com.devoops.service.answerranking;
 
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,8 +15,32 @@ import org.springframework.stereotype.Service;
 public class AnswerRankingService {
 
     private final AnswerRankingDomainRepository answerRankingDomainRepository;
+    private final QuestionDomainRepository questionDomainRepository;
 
     public AnswerRankings findUserRanking(long userId) {
         return answerRankingDomainRepository.findAllByUserId(userId);
+    }
+
+    public void push(Answer answer, long userId) {
+        //유저별 랭킹 가져오기
+        AnswerRankings answerRankings = findUserRanking(userId);
+        Question question = questionDomainRepository.findById(answer.getQuestionId());
+
+        Optional<AnswerRanking> samePrRanking = answerRankings.getSamePrRanking(question.getPullRequestId());
+        //같은 PR이 있다면 덮어쓰기
+        if(samePrRanking.isPresent()) {
+            AnswerRanking answerRanking = samePrRanking.get();
+            answerRankingDomainRepository.update(answerRanking);
+            return;
+        }
+
+        //다 찾다면 가장 느린 것 삭제
+        if(answerRankings.isFull()) {
+            AnswerRanking lastUsedRanking = answerRankings.getLastUsedRanking();
+            answerRankingDomainRepository.deleteById(lastUsedRanking.getId());
+        }
+
+        //새로운 answerRanking 추가하기
+        answerRankingDomainRepository.save(answer, userId);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/PullRequestFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/PullRequestFacadeService.java
@@ -1,8 +1,11 @@
 package com.devoops.service.facade;
 
+import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.QuestionAnswer;
+import com.devoops.dto.response.PullRequestRankingResponses;
 import com.devoops.dto.response.PullRequestReadResponse;
+import com.devoops.service.answerranking.AnswerRankingService;
 import com.devoops.service.pullrequests.PullRequestService;
 import com.devoops.service.question.QuestionService;
 import java.util.List;
@@ -15,11 +18,17 @@ public class PullRequestFacadeService {
 
     private final PullRequestService pullRequestService;
     private final QuestionService questionService;
+    private final AnswerRankingService answerRankingService;
 
     public PullRequestReadResponse read(long pullRequestId) {
         PullRequest pullRequest = pullRequestService.getPullRequest(pullRequestId);
         List<QuestionAnswer> prQuestions = questionService.getAllPrQuestions(pullRequest.getId());
         return PullRequestReadResponse.from(pullRequest, prQuestions);
+    }
+
+    public PullRequestRankingResponses ranking(long userId) {
+        AnswerRankings userRanking = answerRankingService.findUserRanking(userId);
+        return PullRequestRankingResponses.from(userRanking);
     }
 
     public void updateToDone(long pullRequestId) {

--- a/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
@@ -1,12 +1,12 @@
 package com.devoops.service.facade;
 
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.Answers;
-import com.devoops.domain.entity.github.QuestionAnswer;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.request.AnswerPutRequests;
+import com.devoops.service.answerranking.AnswerRankingService;
 import com.devoops.service.question.QuestionService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,17 +15,16 @@ import org.springframework.stereotype.Service;
 public class QuestionFacadeService {
 
     private final QuestionService questionService;
+    private final AnswerRankingService answerRankingService;
 
     public Answer initializeAnswer(long questionId, User user) {
         return questionService.initializeAnswer(questionId, user);
     }
 
-    public List<QuestionAnswer> getAllPrQuestions(long pullRequestsId) {
-        return questionService.getAllPrQuestions(pullRequestsId);
-    }
-
-    public Answer updateAnswer(long answerId, String updateContent) {
-        return questionService.updateAnswer(answerId, updateContent);
+    public Answer updateAnswer(long answerId, String updateContent, long userId) {
+        Answer answer = questionService.updateAnswer(answerId, updateContent);
+        answerRankingService.push(answer, userId);
+        return answer;
     }
 
     public Answers updateAllAnswers(AnswerPutRequests updateRequests) {

--- a/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
@@ -1,0 +1,39 @@
+package com.devoops.service.facade;
+
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Answers;
+import com.devoops.domain.entity.github.QuestionAnswer;
+import com.devoops.domain.entity.user.User;
+import com.devoops.dto.request.AnswerPutRequests;
+import com.devoops.service.question.QuestionService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionFacadeService {
+
+    private final QuestionService questionService;
+
+    public Answer initializeAnswer(long questionId, User user) {
+        return questionService.initializeAnswer(questionId, user);
+    }
+
+    public List<QuestionAnswer> getAllPrQuestions(long pullRequestsId) {
+        return questionService.getAllPrQuestions(pullRequestsId);
+    }
+
+    public Answer updateAnswer(long answerId, String updateContent) {
+        return questionService.updateAnswer(answerId, updateContent);
+    }
+
+    public Answers updateAllAnswers(AnswerPutRequests updateRequests) {
+        return questionService.updateAllAnswers(updateRequests);
+    }
+
+    public void deleteAnswer(long answerId) {
+        questionService.deleteAnswer(answerId);
+    }
+
+}

--- a/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
@@ -2,6 +2,7 @@ package com.devoops;
 
 import com.devoops.config.TestConfig;
 import com.devoops.generator.AnswerGenerator;
+import com.devoops.generator.AnswerRankingGenerator;
 import com.devoops.generator.GithubRepoGenerator;
 import com.devoops.generator.PullRequestGenerator;
 import com.devoops.generator.QuestionGenerator;
@@ -32,5 +33,8 @@ public abstract class BaseServiceTest {
 
     @Autowired
     protected AnswerGenerator answerGenerator;
+
+    @Autowired
+    protected AnswerRankingGenerator answerRankingGenerator;
 }
 

--- a/gss-api-app/src/test/java/com/devoops/service/answerranking/AnswerRankingServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/answerranking/AnswerRankingServiceTest.java
@@ -1,0 +1,126 @@
+package com.devoops.service.answerranking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.devoops.BaseServiceTest;
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.entity.github.RecordStatus;
+import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AnswerRankingServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private AnswerRankingService answerRankingService;
+
+    @Autowired
+    private AnswerRankingDomainRepository answerRankingDomainRepository;
+
+
+    @Nested
+    class Push {
+
+        @Test
+        void PR_랭킹을_저장한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
+                    LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pullRequest, "질문1");
+            Answer answer = answerGenerator.generate(question1, "answer1");
+
+            answerRankingService.push(answer, user.getId());
+
+            AnswerRankings userRanking = answerRankingDomainRepository.findAllByUserId(user.getId());
+            assertThat(userRanking.getRankings()).hasSize(1);
+        }
+
+        @Test
+        void 유저의_PR_랭킹을_모두_가져온다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pr1, "질문1");
+            Question question2 = questionGenerator.generate(pr2, "질문2");
+            Answer answer1 = answerGenerator.generate(question1, "answer1");
+            Answer answer2 = answerGenerator.generate(question2, "answer2");
+            AnswerRanking answerRanking1 = answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
+            AnswerRanking answerRanking2 = answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
+
+            List<Long> userRankingIds = answerRankingService.findUserRanking(user.getId())
+                    .getRankings()
+                    .stream()
+                    .map(AnswerRanking::getId)
+                    .toList();
+
+            assertThat(userRankingIds).containsExactly(answerRanking1.getId(), answerRanking2.getId());
+        }
+
+        @Test
+        void 랭킹_PR에_존재하는_질문의_경우_랭킹내역을_업데이트한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pr1, "질문1");
+            Question question2 = questionGenerator.generate(pr1, "질문2");
+            Answer answer1 = answerGenerator.generate(question1, "answer1");
+            Answer answer2 = answerGenerator.generate(question2, "answer2");
+            answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
+
+            answerRankingService.push(answer2, user.getId());
+
+            AnswerRankings userRanking = answerRankingDomainRepository.findAllByUserId(user.getId());
+            assertAll(
+                    () -> assertThat(userRanking.getRankings()).hasSize(1),
+                    () -> assertThat(userRanking.getRankings().get(0).getQuestionContent()).isEqualTo(
+                            question2.getContent())
+            );
+        }
+
+        @Test
+        void 랭킹_PR이_꽉_찼을_경우_가장_오래된_pr을_삭제하고_새로운_pr을_갱신한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr3 = pullRequestGenerator.generate("PR3", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr4 = pullRequestGenerator.generate("PR4", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pr1, "질문1");
+            Question question2 = questionGenerator.generate(pr2, "질문2");
+            Question question3 = questionGenerator.generate(pr3, "질문3");
+            Question question4 = questionGenerator.generate(pr4, "질문4");
+            Answer answer1 = answerGenerator.generate(question1, "answer1");
+            Answer answer2 = answerGenerator.generate(question2, "answer2");
+            Answer answer3 = answerGenerator.generate(question3, "answer2");
+            Answer answer4 = answerGenerator.generate(question4, "answer2");
+            answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
+            answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
+            answerRankingGenerator.generate(pr3, question3, answer3, user.getId());
+
+            answerRankingService.push(answer4, user.getId());
+
+            List<Long> userRankingPullRequestIds = answerRankingDomainRepository.findAllByUserId(user.getId())
+                    .getRankings()
+                    .stream()
+                    .map(AnswerRanking::getPullRequestId)
+                    .toList();
+
+            assertAll(
+                    () -> assertThat(userRankingPullRequestIds).hasSize(3),
+                    () -> assertThat(userRankingPullRequestIds).containsExactly(pr2.getId(), pr3.getId(), pr4.getId())
+            );
+        }
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRanking.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRanking.java
@@ -1,0 +1,16 @@
+package com.devoops.domain.entity.github;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AnswerRanking {
+
+    private final Long id;
+    private final long questionId;
+    private final long pullRequestId;
+    private final long userId;
+    private final LocalDateTime updatedAt;
+}

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRanking.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRanking.java
@@ -9,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 public class AnswerRanking {
 
     private final Long id;
-    private final long questionId;
     private final long pullRequestId;
+    private final String pullRequestTitle;
     private final long userId;
+    private final long questionId;
+    private final String questionContent;
     private final LocalDateTime updatedAt;
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRankings.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/AnswerRankings.java
@@ -1,0 +1,32 @@
+package com.devoops.domain.entity.github;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AnswerRankings {
+
+    private static final int FULL_THRESHOLD = 3;
+
+    private final List<AnswerRanking> rankings;
+
+    public boolean isFull() {
+        return rankings.size() == FULL_THRESHOLD;
+    }
+
+    public Optional<AnswerRanking> getSamePrRanking(long pullRequestId) {
+        return rankings.stream()
+                .filter(ranking -> ranking.getPullRequestId() == pullRequestId)
+                .findAny();
+    }
+
+    public AnswerRanking getLastUsedRanking() {
+        return rankings.stream()
+                .min(Comparator.comparing(AnswerRanking::getUpdatedAt))
+                .orElseThrow(() -> new RuntimeException("회고가 존재하지 않습니다"));
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
@@ -1,11 +1,12 @@
 package com.devoops.domain.repository.github;
 
+import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.AnswerRankings;
 
 public interface AnswerRankingDomainRepository {
 
-    AnswerRanking save(AnswerRanking answerRanking);
+    AnswerRanking save(Answer answer, long userId);
 
     AnswerRankings findAllByUserId(long userId);
 

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
@@ -10,7 +10,7 @@ public interface AnswerRankingDomainRepository {
 
     AnswerRankings findAllByUserId(long userId);
 
-    AnswerRanking update(AnswerRanking answerRanking);
+    AnswerRanking update(long pullRequestId, long questionId);
 
     void deleteById(long id);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
@@ -1,0 +1,15 @@
+package com.devoops.domain.repository.github;
+
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.AnswerRankings;
+
+public interface AnswerRankingDomainRepository {
+
+    AnswerRanking save(AnswerRanking answerRanking);
+
+    AnswerRankings findAllByUserId(long userId);
+
+    AnswerRanking update(AnswerRanking answerRanking);
+
+    void deleteById(long id);
+}

--- a/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
+++ b/gss-domain/src/main/java/com/devoops/exception/RepositoryErrorCode.java
@@ -10,6 +10,7 @@ public enum RepositoryErrorCode {
     PULL_REQUEST_NOT_FOUND("찾는 풀 리퀘스트가 존재하지 않습니다"),
     QUESTION_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
     ANSWER_NOT_FOUND("찾는 질문이 존재하지 않습니다"),
+    ANSWER_RANKING_NOT_FOUND("찾는 질문 랭킹이 존재하지 않습니다"),
     USER_NOT_FOUND("찾는 회원이 존재하지 않습니다"),
     ;
 

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
@@ -1,5 +1,6 @@
 package com.devoops.jpa.entity.github;
 
+import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.github.AnswerRanking;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,12 +56,9 @@ public class AnswerRankingEntity {
         return new AnswerRanking(id, pullRequestId, pullRequestTitle, userId, questionId, questionContent, updatedAt);
     }
 
-    public void update(AnswerRanking answerRanking) {
-        this.questionId = answerRanking.getQuestionId();
-        this.questionContent = answerRanking.getQuestionContent();
-        this.pullRequestTitle = answerRanking.getPullRequestTitle();
-        this.pullRequestId = answerRanking.getPullRequestId();
-        this.userId = answerRanking.getUserId();
-        this.updatedAt = answerRanking.getUpdatedAt();
+    public void update(QuestionEntity questionEntity) {
+        this.questionId = questionEntity.getId();
+        this.questionContent = questionEntity.getContent();
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
@@ -1,0 +1,36 @@
+package com.devoops.jpa.entity.github;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnswerRankingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "question_id")
+    private long questionId;
+
+    @Column(name = "pull_request_id")
+    private long pullRequestId;
+
+    @Column(name = "user_id")
+    private long userId;
+
+    private LocalDateTime updatedAt;
+
+    public AnswerRankingEntity(long questionId, long pullRequestId, long userId, LocalDateTime updatedAt) {
+        this(null, questionId, pullRequestId, userId, updatedAt);
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,8 +24,15 @@ public class AnswerRankingEntity {
     @Column(name = "question_id")
     private long questionId;
 
+    @NotBlank
+    @Column(name = "content")
+    private String questionContent;
+
     @Column(name = "pull_request_id")
     private long pullRequestId;
+
+    @Column(name = "pull_request_title")
+    private String pullRequestTitle;
 
     @Column(name = "user_id")
     private long userId;
@@ -35,18 +43,22 @@ public class AnswerRankingEntity {
         this(
                 null,
                 answerRanking.getQuestionId(),
+                answerRanking.getQuestionContent(),
                 answerRanking.getPullRequestId(),
+                answerRanking.getPullRequestTitle(),
                 answerRanking.getUserId(),
                 answerRanking.getUpdatedAt()
         );
     }
 
     public AnswerRanking toDomainEntity() {
-        return new AnswerRanking(id, questionId, pullRequestId, userId, updatedAt);
+        return new AnswerRanking(id, pullRequestId, pullRequestTitle, userId, questionId, questionContent, updatedAt);
     }
 
     public void update(AnswerRanking answerRanking) {
         this.questionId = answerRanking.getQuestionId();
+        this.questionContent = answerRanking.getQuestionContent();
+        this.pullRequestTitle = answerRanking.getPullRequestTitle();
         this.pullRequestId = answerRanking.getPullRequestId();
         this.userId = answerRanking.getUserId();
         this.updatedAt = answerRanking.getUpdatedAt();

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/AnswerRankingEntity.java
@@ -1,5 +1,6 @@
 package com.devoops.jpa.entity.github;
 
+import com.devoops.domain.entity.github.AnswerRanking;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,7 +31,24 @@ public class AnswerRankingEntity {
 
     private LocalDateTime updatedAt;
 
-    public AnswerRankingEntity(long questionId, long pullRequestId, long userId, LocalDateTime updatedAt) {
-        this(null, questionId, pullRequestId, userId, updatedAt);
+    public AnswerRankingEntity(AnswerRanking answerRanking) {
+        this(
+                null,
+                answerRanking.getQuestionId(),
+                answerRanking.getPullRequestId(),
+                answerRanking.getUserId(),
+                answerRanking.getUpdatedAt()
+        );
+    }
+
+    public AnswerRanking toDomainEntity() {
+        return new AnswerRanking(id, questionId, pullRequestId, userId, updatedAt);
+    }
+
+    public void update(AnswerRanking answerRanking) {
+        this.questionId = answerRanking.getQuestionId();
+        this.pullRequestId = answerRanking.getPullRequestId();
+        this.userId = answerRanking.getUserId();
+        this.updatedAt = answerRanking.getUpdatedAt();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.devoops.jpa.repository.github;
 
+import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
 import com.devoops.exception.GssRepositoryException;
 import com.devoops.exception.RepositoryErrorCode;
 import com.devoops.jpa.entity.github.AnswerRankingEntity;
+import com.devoops.jpa.entity.github.PullRequestEntity;
+import com.devoops.jpa.entity.github.QuestionEntity;
+import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,10 +20,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRepository {
 
     private final AnswerRankingJpaRepository answerRankingJpaRepository;
+    private final QuestionJpaRepository questionJpaRepository;
 
     @Override
     @Transactional
-    public AnswerRanking save(AnswerRanking answerRanking) {
+    public AnswerRanking save(Answer answer, long userId) {
+        QuestionEntity questionEntity = questionJpaRepository.findById(answer.getQuestionId())
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
+        PullRequestEntity pullRequestEntity = questionEntity.getPullRequest();
+        AnswerRanking answerRanking = new AnswerRanking(
+                null,
+                pullRequestEntity.getId(),
+                pullRequestEntity.getTitle(),
+                userId,
+                answer.getQuestionId(),
+                questionEntity.getContent(),
+                LocalDateTime.now()
+        );
+
         AnswerRankingEntity answerRankingEntity = new AnswerRankingEntity(answerRanking);
         AnswerRankingEntity savedAnswerRanking = answerRankingJpaRepository.save(answerRankingEntity);
         return savedAnswerRanking.toDomainEntity();

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
@@ -25,8 +25,7 @@ public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRep
     @Override
     @Transactional
     public AnswerRanking save(Answer answer, long userId) {
-        QuestionEntity questionEntity = questionJpaRepository.findById(answer.getQuestionId())
-                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
+        QuestionEntity questionEntity = findQuestionById(answer.getQuestionId());
         PullRequestEntity pullRequestEntity = questionEntity.getPullRequest();
         AnswerRanking answerRanking = new AnswerRanking(
                 null,
@@ -54,10 +53,11 @@ public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRep
 
     @Override
     @Transactional
-    public AnswerRanking update(AnswerRanking answerRanking) {
-        AnswerRankingEntity answerRankingEntity = answerRankingJpaRepository.findById(answerRanking.getId())
+    public AnswerRanking update(long pullRequestId, long questionId) {
+        AnswerRankingEntity answerRankingEntity = answerRankingJpaRepository.findByPullRequestId(pullRequestId)
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.ANSWER_RANKING_NOT_FOUND));
-        answerRankingEntity.update(answerRanking);
+        QuestionEntity questionEntity = findQuestionById(questionId);
+        answerRankingEntity.update(questionEntity);
         return answerRankingEntity.toDomainEntity();
     }
 
@@ -65,5 +65,10 @@ public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRep
     @Transactional
     public void deleteById(long id) {
         answerRankingJpaRepository.deleteById(id);
+    }
+
+    private QuestionEntity findQuestionById(long questionId) {
+        return questionJpaRepository.findById(questionId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.devoops.jpa.repository.github;
+
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
+import com.devoops.exception.GssRepositoryException;
+import com.devoops.exception.RepositoryErrorCode;
+import com.devoops.jpa.entity.github.AnswerRankingEntity;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRepository {
+
+    private final AnswerRankingJpaRepository answerRankingJpaRepository;
+
+    @Override
+    @Transactional
+    public AnswerRanking save(AnswerRanking answerRanking) {
+        AnswerRankingEntity answerRankingEntity = new AnswerRankingEntity(answerRanking);
+        AnswerRankingEntity savedAnswerRanking = answerRankingJpaRepository.save(answerRankingEntity);
+        return savedAnswerRanking.toDomainEntity();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AnswerRankings findAllByUserId(long userId) {
+        return answerRankingJpaRepository.findAllByUserId(userId)
+                .stream()
+                .map(AnswerRankingEntity::toDomainEntity)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), AnswerRankings::new));
+    }
+
+    @Override
+    @Transactional
+    public AnswerRanking update(AnswerRanking answerRanking) {
+        AnswerRankingEntity answerRankingEntity = answerRankingJpaRepository.findById(answerRanking.getId())
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.ANSWER_RANKING_NOT_FOUND));
+        answerRankingEntity.update(answerRanking);
+        return answerRankingEntity.toDomainEntity();
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(long id) {
+        answerRankingJpaRepository.deleteById(id);
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
@@ -1,0 +1,10 @@
+package com.devoops.jpa.repository.github;
+
+import com.devoops.jpa.entity.github.AnswerRankingEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRankingJpaRepository extends JpaRepository<AnswerRankingEntity, Long> {
+
+    List<AnswerRankingEntity> findAllByUserId(long userId);
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
@@ -2,9 +2,12 @@ package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.AnswerRankingEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerRankingJpaRepository extends JpaRepository<AnswerRankingEntity, Long> {
 
     List<AnswerRankingEntity> findAllByUserId(long userId);
+
+    Optional<AnswerRankingEntity> findByPullRequestId(long pullRequestId);
 }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/AnswerRankingGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/AnswerRankingGenerator.java
@@ -1,0 +1,34 @@
+package com.devoops.generator;
+
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.jpa.entity.github.AnswerRankingEntity;
+import com.devoops.jpa.repository.github.AnswerRankingJpaRepository;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnswerRankingGenerator {
+
+    @Autowired
+    private AnswerRankingJpaRepository answerRankingJpaRepository;
+
+    public AnswerRanking generate(PullRequest pullRequest, Question question, Answer answer, long userId) {
+        AnswerRanking answerRanking = new AnswerRanking(
+                null,
+                pullRequest.getId(),
+                pullRequest.getTitle(),
+                userId,
+                answer.getQuestionId(),
+                question.getContent(),
+                LocalDateTime.now()
+        );
+
+        AnswerRankingEntity answerRankingEntity = new AnswerRankingEntity(answerRanking);
+        AnswerRankingEntity savedAnswerRanking = answerRankingJpaRepository.save(answerRankingEntity);
+        return savedAnswerRanking.toDomainEntity();
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-94

# 🔂 변경 내역
- 이어서 회고하기를 위해 pr 및 question 정보를 포함한 랭킹 table을 만듭니다.
- 만약 겹치는 pr이 있다면 -> question 만 업데이트
- 만약 겹치는 pr이 없고 & 랭킹이 꽉찼다면 -> 가장 오래된 pr 삭제 후, pr 삽입
- 만약 겹치는 pr이 없고 & 랭킹이 꽉차지 않았다면 -> 랭킹에 pr 삽입

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 풀리퀘스트 랭킹 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 풀리퀘스트 랭킹 응답 및 관련 데이터 전송 객체가 도입되었습니다.
  * 답변 랭킹 관리 및 조회를 위한 서비스와 도메인/저장소 구조가 추가되었습니다.

* **버그 수정**
  * 답변 삭제 엔드포인트의 메서드명이 올바르게 수정되었습니다.

* **테스트**
  * 답변 랭킹 서비스의 동작을 검증하는 테스트가 추가되었습니다.
  * 테스트용 답변 랭킹 생성 유틸리티가 도입되었습니다.

* **기타**
  * 내부 서비스 및 컨트롤러 의존성이 일부 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->