### PR TITLE
[GSS-106] 중복 계정의 유저가 가입하는 문제 방지

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/service/user/UserService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/user/UserService.java
@@ -12,9 +12,10 @@ public class UserService {
     private final UserDomainRepository userDomainRepository;
 
     public User save(User user) {
+        long providerId = user.getProviderId();
         Long userId = user.getId();
-        if (userId != null && userDomainRepository.existsById(userId)) {
-            return userDomainRepository.findById(userId);
+        if (userDomainRepository.existsByProviderId(providerId)) {
+            return userDomainRepository.findByProviderId(userId);
         }
         return userDomainRepository.saveUser(user);
     }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/user/UserDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/user/UserDomainRepository.java
@@ -7,7 +7,11 @@ public interface UserDomainRepository {
 
     User findById(Long id);
 
+    User findByProviderId(Long providerId);
+
     boolean existsById(Long id);
+
+    boolean existsByProviderId(Long externalId);
 
     User saveUser(User user);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.devoops.exception.GssRepositoryException;
 import com.devoops.exception.RepositoryErrorCode;
 import com.devoops.jpa.entity.github.AnswerEntity;
 import com.devoops.jpa.entity.github.QuestionEntity;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +38,7 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
 
     @Override
     @Transactional
-    public void deleteById(long answerId){
+    public void deleteById(long answerId) {
         answerJpaRepository.deleteById(answerId);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/user/UserDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/user/UserDomainRepositoryImpl.java
@@ -31,10 +31,26 @@ public class UserDomainRepositoryImpl implements UserDomainRepository {
                 .toDomainEntity(githubToken);
     }
 
+    @Override
+    public User findByProviderId(Long providerId) {
+        UserEntity userEntity = userJpaRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new RuntimeException("EntityNotFound 공통 예외 처리 필요"));
+        GithubToken githubToken = githubTokenJpaRepository.findByUser_Id(userEntity.getId())
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.GITHUB_TOKEN_NOT_FOUND))
+                .toDomainEntity();
+        return userEntity.toDomainEntity(githubToken);
+    }
+
     @Transactional(readOnly = true)
     @Override
     public boolean existsById(Long id) {
         return userJpaRepository.existsById(id);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public boolean existsByProviderId(Long externalId) {
+        return userJpaRepository.existsByProviderId(externalId);
     }
 
     @Transactional

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/user/UserJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/user/UserJpaRepository.java
@@ -1,8 +1,12 @@
 package com.devoops.jpa.repository.user;
 
 import com.devoops.jpa.entity.user.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
+    boolean existsByProviderId(Long id);
+
+    Optional<UserEntity> findByProviderId(Long providerId);
 }


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-106

# 🔂 변경 내역
중복된 계정의 유저가 반복적으로 가입할 수 있는 문제를 방지하기 위해,
providerId(github 측에서 발급한 id)로 조회하여 user가 있다면 해당 유저를 반환하도록 로직을 수정합니다.

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * providerId를 이용한 사용자 조회 및 존재 여부 확인 기능이 추가되었습니다.

* **버그 수정**
  * 사용자 저장 시 providerId 기반으로 기존 사용자 확인 로직이 개선되었습니다.

* **스타일**
  * 일부 코드의 포맷팅 및 불필요한 import가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->