### PR TITLE
[GSS-108] Bearer prefix를 파싱하도록 수정

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/auth/AuthUserArgumentResolver.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/auth/AuthUserArgumentResolver.java
@@ -1,8 +1,11 @@
 package com.devoops.controller.auth;
 
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.service.auth.AuthService;
 import com.devoops.service.auth.jwt.AccessToken;
 import com.devoops.service.user.UserService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -16,6 +19,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Slf4j
 @RequiredArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String BEARER = "Bearer ";
 
     private final AuthService authService;
     private final UserService userService;
@@ -34,7 +39,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         String accessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
         if (StringUtils.isBlank(accessToken)) {
-            throw new RuntimeException("401 인증 에러"); //TODO 추후 커스텀 에러로 수정
+            throw new GssException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
         String providerId = authService.resolveToken(new AccessToken(accessToken));
         return userService.findById(Long.parseLong(providerId));

--- a/gss-api-app/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/gss-api-app/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     //4XX
     REPOSITORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "레포지토리를 찾을 수 없습니다"),
     MALFORMED_GITHUB_REPOSITORY_URL(HttpStatus.BAD_REQUEST, "잘못된 형식의 레포지토리 url입니다"),
+    UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "잘못된 유저 접근입니다"),
 
     FIELD_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
     URL_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),

--- a/gss-api-app/src/main/java/com/devoops/service/auth/jwt/AccessToken.java
+++ b/gss-api-app/src/main/java/com/devoops/service/auth/jwt/AccessToken.java
@@ -1,5 +1,7 @@
 package com.devoops.service.auth.jwt;
 
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
 import java.time.Duration;
 import java.util.Date;
 import javax.crypto.SecretKey;
@@ -7,12 +9,20 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class AccessToken extends JwtToken {
 
+    private static final String ACCESS_TOKEN_PREFIX = "Bearer ";
     private static final TokenType TOKEN_TYPE = TokenType.ACCESS_TOKEN;
 
     private final String token;
+
+
+    public AccessToken(String token) {
+        if(!token.startsWith(ACCESS_TOKEN_PREFIX)) {
+            throw new GssException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+        }
+        this.token = token.substring(ACCESS_TOKEN_PREFIX.length()).trim();
+    }
 
     public AccessToken(
             String value,

--- a/gss-api-app/src/test/java/com/devoops/controller/AuthControllerTest.java
+++ b/gss-api-app/src/test/java/com/devoops/controller/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest extends BaseControllerTest {
                     .body()
                     .as(UserTokenResponse.class);
 
-            AccessToken accessToken = new AccessToken(userTokenResponse.accessToken());
+            AccessToken accessToken = new AccessToken("Bearer " + userTokenResponse.accessToken());
             String resolvedToken = jwtTokenManager.resolveToken(accessToken);
             assertThat(resolvedToken).isEqualTo(String.valueOf(saveUser.getId()));
         }
@@ -81,7 +81,7 @@ class AuthControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .header(HttpHeaders.COOKIE, "refreshToken=" + refreshToken.getToken())
                     .when().post("/api/auth/logout")
                     .then().statusCode(HttpStatus.NO_CONTENT.value());
@@ -98,7 +98,7 @@ class AuthControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .header(HttpHeaders.COOKIE, "refreshToken=" + refreshToken.getToken())
                     .when().post("/api/auth/logout")
                     .then().statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value()); //TODO 추후 401로 변경
@@ -111,7 +111,7 @@ class AuthControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .when().post("/api/auth/logout")
                     .then()
                     .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value()); //TODO 추후 400으로 변경

--- a/gss-api-app/src/test/java/com/devoops/controller/repository/RepositoryControllerTest.java
+++ b/gss-api-app/src/test/java/com/devoops/controller/repository/RepositoryControllerTest.java
@@ -39,7 +39,7 @@ class RepositoryControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .queryParam("page", 0L)
                     .queryParam("size", 6L)
                     .pathParam("repositoryId", repo.getId())
@@ -59,7 +59,7 @@ class RepositoryControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .queryParam("page", 0L)
                     .queryParam("size", 6L)
                     .pathParam("repositoryId", repo.getId())
@@ -79,7 +79,7 @@ class RepositoryControllerTest extends BaseControllerTest {
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.AUTHORIZATION, accessToken.getToken())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getToken())
                     .body(request)
                     .when().post("/api/repositories")
                     .then().statusCode(HttpStatus.CREATED.value());

--- a/gss-api-app/src/test/java/com/devoops/service/auth/AuthServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/auth/AuthServiceTest.java
@@ -62,7 +62,7 @@ class AuthServiceTest extends BaseServiceTest {
 
         private String resolveTokenValue(String tokenValue, TokenType tokenType) {
             if(tokenType.isAccess()) {
-                return jwtTokenManager.resolveToken(new AccessToken(tokenValue));
+                return jwtTokenManager.resolveToken(new AccessToken("Bearer " + tokenValue));
             }
             return jwtTokenManager.resolveToken(new RefreshToken(tokenValue));
         }


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-108

# 🔂 변경 내역:
유저 인증 과정에서 Bearer {accessToken}으로 스펙을 정햇음에도 Bearer를 그대로 포함해 파싱하고 있어 에러 발생
-> accessToken 값만 따로 가져와 파싱하도록 변경

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증 토큰이 "Bearer " 접두사로 시작하지 않을 경우, 보다 명확한 예외 메시지와 함께 인증 오류가 발생하도록 개선되었습니다.

* **테스트**
  * 모든 테스트에서 Authorization 헤더에 "Bearer " 접두사가 올바르게 포함되도록 수정되었습니다.

* **기타**
  * 인증 관련 오류 코드와 메시지가 추가되어, 인증 실패 시 더 명확한 안내가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->