### PR TITLE
[GSS-104] 회고 상태 변화 코드 작성

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/pullrequests/PullRequestController.java
@@ -2,6 +2,7 @@ package com.devoops.controller.pullrequests;
 
 import com.devoops.controller.auth.AuthUser;
 import com.devoops.controller.docs.PullRequestControllerSwagger;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.response.PullRequestDetailReadResponse;
 import com.devoops.dto.response.PullRequestRankingResponses;
@@ -50,7 +51,7 @@ public class PullRequestController implements PullRequestControllerSwagger {
             @AuthUser User user,
             @PathVariable(name = "pullRequestId") long pullRequestId
     ) {
-        pullRequestFacadeService.updateToDone(pullRequestId);
+        pullRequestFacadeService.updateStatus(pullRequestId, RecordStatus.DONE);
         return ResponseEntity.ok().build();
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/question/QuestionController.java
@@ -54,8 +54,6 @@ public class QuestionController implements QuestionControllerSwagger {
             @PathVariable(name = "answerId") long answerId,
             @Valid @RequestBody AnswerUpdateRequest request
     ) {
-
-        //TODO ranking 갱신
         Answer updatedAnswer = questionFacadeService.updateAnswer(answerId, request.content(), user.getId());
         AnswerUpdateResponse response = new AnswerUpdateResponse(updatedAnswer);
         return ResponseEntity.ok(response);

--- a/gss-api-app/src/main/java/com/devoops/service/answer/AnswerService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/answer/AnswerService.java
@@ -1,0 +1,21 @@
+package com.devoops.service.answer;
+
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final AnswerDomainRepository answerDomainRepository;
+
+    public long getAnswerCountByPullRequestId(long pullRequestId) {
+        return answerDomainRepository.getAnswerCountByPullRequestId(pullRequestId);
+    }
+
+    public Answer findById(long answerId) {
+        return answerDomainRepository.findById(answerId);
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/service/facade/PullRequestFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/PullRequestFacadeService.java
@@ -3,6 +3,7 @@ package com.devoops.service.facade;
 import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.QuestionAnswer;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.dto.response.PullRequestDetailReadResponse;
 import com.devoops.dto.response.PullRequestRankingResponses;
 import com.devoops.dto.response.PullRequestReadResponse;
@@ -40,8 +41,8 @@ public class PullRequestFacadeService {
         return PullRequestRankingResponses.from(userRanking);
     }
 
-    public void updateToDone(long pullRequestId) {
-        pullRequestService.updateToDone(pullRequestId);
+    public void updateStatus(long pullRequestId, RecordStatus status) {
+        pullRequestService.updateStatus(pullRequestId, status);
     }
 
     private List<String> getUniqueCategories(List<QuestionAnswer> questionAnswers) {

--- a/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
@@ -6,6 +6,7 @@ import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.request.AnswerPutRequests;
+import com.devoops.service.answer.AnswerService;
 import com.devoops.service.answerranking.AnswerRankingService;
 import com.devoops.service.pullrequests.PullRequestService;
 import com.devoops.service.question.QuestionService;
@@ -18,6 +19,7 @@ public class QuestionFacadeService {
 
     private final PullRequestService pullRequestService;
     private final QuestionService questionService;
+    private final AnswerService answerService;
     private final AnswerRankingService answerRankingService;
 
     public Answer initializeAnswer(long questionId, User user) {
@@ -39,7 +41,12 @@ public class QuestionFacadeService {
     }
 
     public void deleteAnswer(long answerId) {
+        Answer answer = answerService.findById(answerId);
+        PullRequest pullRequest = pullRequestService.findByQuestionId(answer.getQuestionId());
+        long answerCount = answerService.getAnswerCountByPullRequestId(pullRequest.getId());
+        if(answerCount == 1) {
+            pullRequestService.updateStatus(pullRequest.getId(), RecordStatus.PENDING);
+        }
         questionService.deleteAnswer(answerId);
     }
-
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/QuestionFacadeService.java
@@ -1,11 +1,13 @@
 package com.devoops.service.facade;
 
 import com.devoops.domain.entity.github.Answer;
-import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.Answers;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.request.AnswerPutRequests;
 import com.devoops.service.answerranking.AnswerRankingService;
+import com.devoops.service.pullrequests.PullRequestService;
 import com.devoops.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,10 +16,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class QuestionFacadeService {
 
+    private final PullRequestService pullRequestService;
     private final QuestionService questionService;
     private final AnswerRankingService answerRankingService;
 
     public Answer initializeAnswer(long questionId, User user) {
+        PullRequest pullRequest = pullRequestService.findByQuestionId(questionId);
+        if (pullRequest.isPending()) {
+            pullRequestService.updateStatus(pullRequest.getId(), RecordStatus.PROGRESS);
+        }
         return questionService.initializeAnswer(questionId, user);
     }
 

--- a/gss-api-app/src/main/java/com/devoops/service/pullrequests/PullRequestService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/pullrequests/PullRequestService.java
@@ -1,6 +1,7 @@
 package com.devoops.service.pullrequests;
 
 import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.repository.github.PullRequestDomainRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,8 +12,12 @@ public class PullRequestService {
 
     private final PullRequestDomainRepository pullRequestRepository;
 
-    public PullRequest updateToDone(long pullRequestId) {
-        return pullRequestRepository.updateToDone(pullRequestId);
+    public PullRequest updateStatus(long pullRequestId, RecordStatus status) {
+        return pullRequestRepository.updateStatus(pullRequestId, status);
+    }
+
+    public PullRequest findByQuestionId(long questionId) {
+        return pullRequestRepository.findByQuestionId(questionId);
     }
 
     public PullRequest getPullRequest(long pullRequestId) {

--- a/gss-api-app/src/test/java/com/devoops/service/facade/QuestionFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/QuestionFacadeServiceTest.java
@@ -1,0 +1,75 @@
+package com.devoops.service.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.devoops.BaseServiceTest;
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.entity.github.RecordStatus;
+import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.PullRequestDomainRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class QuestionFacadeServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private QuestionFacadeService questionFacadeService;
+
+    @Autowired
+    private PullRequestDomainRepository pullRequestDomainRepository;
+
+    @Nested
+    class StatusChange {
+
+        @Test
+        void 최소_하나의_회고가_생성되면_PR상태가_progress로_변경된다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
+                    LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pullRequest, "질문1");
+
+            questionFacadeService.initializeAnswer(question1.getId(), user);
+
+            PullRequest progressPullRequest = pullRequestDomainRepository.findById(pullRequest.getId());
+            assertThat(progressPullRequest.getRecordStatus()).isEqualTo(RecordStatus.PROGRESS);
+        }
+
+        @Test
+        void 회고를_삭제할_때_PR의_회고가_남아있다면_PR은_PROGRESS를_유지한다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS, repo,
+                    LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pullRequest, "질문1");
+            Question question2 = questionGenerator.generate(pullRequest, "질문2");
+            Answer answer1 = answerGenerator.generate(question1, "대답1");
+            Answer answer2 = answerGenerator.generate(question2, "대답2");
+
+            questionFacadeService.deleteAnswer(answer1.getId());
+
+            PullRequest progressPullRequest = pullRequestDomainRepository.findById(pullRequest.getId());
+            assertThat(progressPullRequest.getRecordStatus()).isEqualTo(RecordStatus.PROGRESS);
+        }
+
+        @Test
+        void 마지막_회고를_삭제하면_PR은_PENDING으로_변경된다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS, repo,
+                    LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pullRequest, "질문1");
+            Answer answer1 = answerGenerator.generate(question1, "대답1");
+
+            questionFacadeService.deleteAnswer(answer1.getId());
+
+            PullRequest progressPullRequest = pullRequestDomainRepository.findById(pullRequest.getId());
+            assertThat(progressPullRequest.getRecordStatus()).isEqualTo(RecordStatus.PENDING);
+        }
+    }
+}

--- a/gss-api-app/src/test/java/com/devoops/service/pullrequests/PullRequestServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/pullrequests/PullRequestServiceTest.java
@@ -27,7 +27,7 @@ class PullRequestServiceTest extends BaseServiceTest {
             PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
                     LocalDateTime.now());
 
-            PullRequest updatedPullRequest = pullRequestService.updateToDone(pullRequest.getId());
+            PullRequest updatedPullRequest = pullRequestService.updateStatus(pullRequest.getId(), RecordStatus.DONE);
 
             assertThat(updatedPullRequest.getRecordStatus()).isEqualTo(RecordStatus.DONE);
         }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
@@ -20,4 +20,8 @@ public class PullRequest {
     private final RecordStatus recordStatus;
     private final LocalDateTime mergedAt;
     private final String tag;
+
+    public boolean isPending() {
+        return recordStatus == RecordStatus.PENDING;
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
@@ -6,6 +6,10 @@ public interface AnswerDomainRepository {
 
     Answer save(Answer answer);
 
+    Answer findById(long answerId);
+
+    long getAnswerCountByPullRequestId(long pullRequestId);
+
     Answer updateById(long answerId, String content);
 
     void deleteById(long answerId);

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/PullRequestDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/PullRequestDomainRepository.java
@@ -2,6 +2,7 @@ package com.devoops.domain.repository.github;
 
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.PullRequests;
+import com.devoops.domain.entity.github.RecordStatus;
 
 public interface PullRequestDomainRepository {
 
@@ -11,5 +12,7 @@ public interface PullRequestDomainRepository {
 
     PullRequests findPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page);
 
-    PullRequest updateToDone(long pullRequestId);
+    PullRequest findByQuestionId(long questionId);
+
+    PullRequest updateStatus(long pullRequestId, RecordStatus status);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/PullRequestEntity.java
@@ -82,6 +82,10 @@ public class PullRequestEntity extends BaseTimeEntity {
         this.recordStatus = RecordStatus.DONE;
     }
 
+    public void updateStatus(RecordStatus recordStatus) {
+        this.recordStatus = recordStatus;
+    }
+
     public PullRequest toDomainEntity() {
         return new PullRequest(
             this.id,

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -28,6 +28,18 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
     }
 
     @Override
+    public Answer findById(long answerId) {
+        return answerJpaRepository.findById(answerId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.ANSWER_NOT_FOUND))
+                .toDomainEntity();
+    }
+
+    @Override
+    public long getAnswerCountByPullRequestId(long pullRequestId) {
+        return answerJpaRepository.getAnswerCountByPullRequestId(pullRequestId);
+    }
+
+    @Override
     @Transactional
     public Answer updateById(long answerId, String content) {
         AnswerEntity answerEntity = answerJpaRepository.findById(answerId)

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
@@ -2,7 +2,19 @@ package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.AnswerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {
 
+    @Query("""
+            select count(ae)
+            from AnswerEntity ae
+                        where ae.question.id in (
+                                    select qe.id
+                                    from QuestionEntity qe
+                                    where qe.pullRequest.id = :pullRequestId
+                              )
+            """)
+    long getAnswerCountByPullRequestId(@Param(value = "pullRequestId") long pullRequestId);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
@@ -2,13 +2,13 @@ package com.devoops.jpa.repository.github;
 
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.PullRequests;
-import com.devoops.domain.entity.github.QuestionAnswer;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.repository.github.PullRequestDomainRepository;
 import com.devoops.exception.GssRepositoryException;
 import com.devoops.exception.RepositoryErrorCode;
 import com.devoops.jpa.entity.github.GithubRepositoryEntity;
 import com.devoops.jpa.entity.github.PullRequestEntity;
-import java.util.List;
+import com.devoops.jpa.entity.github.QuestionEntity;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +23,7 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
 
     private final PullRequestJpaRepository pullRequestRepository;
     private final GithubRepoJpaRepository githubRepoRepository;
+    private final QuestionJpaRepository questionJpaRepository;
 
     @Override
     @Transactional
@@ -54,10 +55,19 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
 
     @Override
     @Transactional
-    public PullRequest updateToDone(long pullRequestId) {
+    public PullRequest updateStatus(long pullRequestId, RecordStatus status) {
         PullRequestEntity pullRequest = pullRequestRepository.findById(pullRequestId)
                 .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.PULL_REQUEST_NOT_FOUND));
-        pullRequest.updateToDone();
+        pullRequest.updateStatus(status);
         return pullRequest.toDomainEntity();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PullRequest findByQuestionId(long questionId) {
+        QuestionEntity questionEntity = questionJpaRepository.findById(questionId)
+                .orElseThrow(() -> new GssRepositoryException(RepositoryErrorCode.QUESTION_NOT_FOUND));
+        return questionEntity.getPullRequest()
+                .toDomainEntity();
     }
 }


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-104

# 🔂 변경 내역

기존의 회고를 추가, 삭제했던 로직에 있어서 PullRequest에 첫 회고 선택이라면 Pending > Progress를 수행하고,
마지막 회고를 삭제한다면 Progress > PENDING으로 상태 변화를 하도록 수정합니다.

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 답변 개수 조회 및 ID로 답변 조회 기능이 추가되었습니다.
  * 질문 ID로 연관된 풀 리퀘스트를 조회할 수 있습니다.

* **버그 수정**
  * 풀 리퀘스트 상태 변경이 보다 일반화되어 다양한 상태로 전환이 가능합니다.

* **개선 사항**
  * 답변 생성 및 삭제 시, 풀 리퀘스트 상태가 자동으로 PENDING/PROGRESS로 변경됩니다.
  * 코드 구조가 개선되어 상태 업데이트 및 조회 기능이 확장되었습니다.

* **테스트**
  * 답변 생성/삭제에 따른 풀 리퀘스트 상태 변화에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->