### PR TITLE
[GSS-116] 유저 정보 조회 API 구현

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/user/UserController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/user/UserController.java
@@ -1,0 +1,24 @@
+package com.devoops.controller.user;
+
+import com.devoops.dto.response.UserReadResponse;
+import com.devoops.service.facade.UserFacadeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserFacadeService userFacadeService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserReadResponse> getUserInfo(@PathVariable("userId") long userId) {
+        UserReadResponse response = userFacadeService.getUser(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/UserReadResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/UserReadResponse.java
@@ -1,0 +1,20 @@
+package com.devoops.dto.response;
+
+import com.devoops.domain.entity.user.User;
+
+public record UserReadResponse(
+        long id,
+        long externalId,
+        String nickname,
+        String profileImageUrl
+) {
+
+    public UserReadResponse(User user) {
+        this(
+                user.getId(),
+                user.getProviderId(),
+                user.getNickname(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/gss-api-app/src/main/java/com/devoops/dto/response/UserReadResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/UserReadResponse.java
@@ -4,7 +4,6 @@ import com.devoops.domain.entity.user.User;
 
 public record UserReadResponse(
         long id,
-        long externalId,
         String nickname,
         String profileImageUrl
 ) {
@@ -12,7 +11,6 @@ public record UserReadResponse(
     public UserReadResponse(User user) {
         this(
                 user.getId(),
-                user.getProviderId(),
                 user.getNickname(),
                 user.getProfileImageUrl()
         );

--- a/gss-api-app/src/main/java/com/devoops/dto/response/UserSaveResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/UserSaveResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record UserSaveResponse(
 
         @Schema(description = "깃허브 회원 아이디", example = "234558")
-        long providerId,
+        long id,
 
         @Schema(description = "깃허브 회원 닉네임", example = "my_nickname")
         String nickname,
@@ -22,6 +22,6 @@ public record UserSaveResponse(
 ) {
 
     public UserSaveResponse(User user, String accessToken, String refreshToken) {
-        this(user.getProviderId(), user.getNickname(), user.getProfileImageUrl(), accessToken, refreshToken);
+        this(user.getId(), user.getNickname(), user.getProfileImageUrl(), accessToken, refreshToken);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/UserFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/UserFacadeService.java
@@ -1,0 +1,19 @@
+package com.devoops.service.facade;
+
+import com.devoops.domain.entity.user.User;
+import com.devoops.dto.response.UserReadResponse;
+import com.devoops.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacadeService {
+
+    private final UserService userService;
+
+    public UserReadResponse getUser(long userId) {
+        User user = userService.findById(userId);
+        return new UserReadResponse(user);
+    }
+}

--- a/gss-api-app/src/test/java/com/devoops/controller/user/UserControllerTest.java
+++ b/gss-api-app/src/test/java/com/devoops/controller/user/UserControllerTest.java
@@ -1,0 +1,39 @@
+package com.devoops.controller.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.devoops.BaseControllerTest;
+import com.devoops.domain.entity.user.User;
+import com.devoops.dto.response.UserReadResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class UserControllerTest extends BaseControllerTest {
+
+
+    @Nested
+    class GetUser {
+
+        @Test
+        void 유저_정보를_조회할_수_있다() {
+            User user = userGenerator.generate("김건우");
+
+            UserReadResponse readResponse = RestAssured.given()
+                    .contentType(ContentType.JSON)
+                    .pathParam("userId", user.getId())
+                    .when().get("/api/users/{userId}")
+                    .then().statusCode(HttpStatus.OK.value())
+                    .extract().as(UserReadResponse.class);
+
+            assertAll(
+                    () -> assertThat(readResponse.id()).isEqualTo(user.getId()),
+                    () -> assertThat(readResponse.nickname()).isEqualTo(user.getNickname()),
+                    () -> assertThat(readResponse.profileImageUrl()).isEqualTo(user.getProfileImageUrl())
+            );
+        }
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-116

# 🔂 변경 내역

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 정보를 조회할 수 있는 GET API 엔드포인트(`/api/users/{userId}`)가 추가되었습니다.

* **버그 수정**
  * 사용자 저장 응답에서 필드명이 `providerId`에서 `id`로 변경되었습니다.

* **테스트**
  * 사용자 정보 조회 API에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->