### PR TITLE
[GSS-125] Github URL 검증 에러코드 구분

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/docs/AuthControllerSwagger.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/docs/AuthControllerSwagger.java
@@ -1,6 +1,5 @@
 package com.devoops.controller.docs;
 
-import com.devoops.controller.auth.AuthUser;
 import com.devoops.domain.entity.user.User;
 import com.devoops.dto.request.LogoutV1Request;
 import com.devoops.dto.request.RefreshTokenV1Request;
@@ -10,17 +9,13 @@ import com.devoops.dto.response.UserTokenRefreshResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Auth API")
 @SecurityRequirement(name = "Authorization")
@@ -68,9 +63,9 @@ public interface AuthControllerSwagger {
             summary = "로그 아웃",
             parameters = {
                     @Parameter(
-                            name = "refreshToken",
+                            name = "Cookie",
                             description = "리프레시 토큰 (쿠키에 담김)",
-                            in = ParameterIn.COOKIE,
+                            in = ParameterIn.HEADER,
                             required = true,
                             example = "refreshToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     )
@@ -81,7 +76,7 @@ public interface AuthControllerSwagger {
             )}
     )
     ResponseEntity<Void> logout(
-            @Parameter(hidden = true)User user,
+            @Parameter(hidden = true) User user,
             String token
     );
 

--- a/gss-api-app/src/main/java/com/devoops/controller/docs/RepositoryControllerSwagger.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/docs/RepositoryControllerSwagger.java
@@ -96,7 +96,6 @@ public interface RepositoryControllerSwagger {
 
     @Operation(
             summary = "나의 레포지토리 목록 조회",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = RepositorySaveRequest.class))),
             responses = {@ApiResponse(
                     responseCode = "200",
                     description = "나의 레포지토리 목록 조회 성공",

--- a/gss-api-app/src/main/java/com/devoops/dto/request/GithubRepoUrl.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/request/GithubRepoUrl.java
@@ -13,11 +13,13 @@ public class GithubRepoUrl {
     private static final String PATH_DELIMITER = "/";
     private static final String GIT_SUFFIX_REGEX = "\\.git$";
 
+    private final String url;
     private final String owner;
     private final String repoName;
 
     public GithubRepoUrl(String url) {
         String[] pathSegments = parseUrl(url);
+        this.url = url;
         this.owner = pathSegments[0];
         this.repoName = pathSegments[1].replaceAll(GIT_SUFFIX_REGEX, "");
     }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -1,5 +1,7 @@
 package com.devoops.service.facade;
 
+import static com.devoops.Constants.INITIAL_PULL_REQUEST_COUNT;
+
 import com.devoops.command.request.RepositoryCreateCommand;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.PullRequests;
@@ -13,8 +15,7 @@ import com.devoops.service.repository.RepositoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-
-import static com.devoops.Constants.INITIAL_PULL_REQUEST_COUNT;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class RepositoryFacadeService {
     private final GitHubService gitHubService;
     private final ApplicationEventPublisher eventPublisher;
 
+    @Transactional
     public GithubRepository save(RepositorySaveRequest request, User user) {
         GithubRepoUrl repoUrl = new GithubRepoUrl(request.url());
         GithubRepository savedRepository = saveRepository(repoUrl, user);
@@ -35,12 +37,12 @@ public class RepositoryFacadeService {
     private GithubRepository saveRepository(GithubRepoUrl url, User user) {
         GithubRepoInfoResponse repositoryInfo = gitHubService.getRepositoryInfo(url, user.getGithubToken());
         RepositoryCreateCommand createCommand = new RepositoryCreateCommand(
-            user.getId(),
-            repositoryInfo.name(),
-            repositoryInfo.url(),
-            repositoryInfo.getOwnerName(),
-            INITIAL_PULL_REQUEST_COUNT,
-            repositoryInfo.id()
+                user.getId(),
+                repositoryInfo.name(),
+                url.getUrl(),
+                repositoryInfo.getOwnerName(),
+                INITIAL_PULL_REQUEST_COUNT,
+                repositoryInfo.id()
         );
         return repositoryService.save(createCommand);
     }

--- a/gss-client/gss-github-client/build.gradle
+++ b/gss-client/gss-github-client/build.gradle
@@ -11,6 +11,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(":gss-common")
+
     //json-naming
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 

--- a/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
@@ -1,12 +1,14 @@
 package com.devoops.client;
 
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import reactor.core.publisher.Mono;
-
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -15,21 +17,23 @@ public class GithubExchangeFilterFunction {
     @Bean
     public ExchangeFilterFunction githubErrorLogger() {
         return (request, next) -> next.exchange(request)
-            .flatMap(response -> {
-                if (response.statusCode().isError()) {
-                    return response.bodyToMono(String.class).flatMap(body -> {
-                        log.error("GitHub API Error: {}", Map.of(
-                            "method", request.method(),
-                            "url", request.url(),
-                            "status", response.statusCode(),
-                            "response", body
-                        ));
-                        // TODO: 커스텀한 예외로 변경 필요
-                        return Mono.error(new RuntimeException("GitHub API error: " + body));
-                    });
-                }
+                .flatMap(response -> {
+                    if (response.statusCode().isError()) {
+                        return response.bodyToMono(String.class).flatMap(body -> {
+                            log.error("GitHub API Error: {}", Map.of(
+                                    "method", request.method(),
+                                    "url", request.url(),
+                                    "status", response.statusCode(),
+                                    "response", body
+                            ));
+                            if (response.statusCode().isSameCodeAs(HttpStatusCode.valueOf(404))) {
+                                return Mono.error(new GssException(ErrorCode.MALFORMED_GITHUB_REPOSITORY_URL));
+                            }
+                            return Mono.error(new GssException(ErrorCode.GITHUB_CLIENT_ERROR));
+                        });
+                    }
 
-                return Mono.just(response);
-            });
+                    return Mono.just(response);
+                });
     }
 }

--- a/gss-client/gss-github-client/src/main/java/com/devoops/config/GithubClientConfig.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/config/GithubClientConfig.java
@@ -4,6 +4,7 @@ import com.devoops.client.GitHubClient;
 import com.devoops.client.GitHubWebClientProperties;
 import io.netty.channel.ChannelOption;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,8 @@ import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
 
+
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(GitHubWebClientProperties.class)
@@ -26,9 +29,7 @@ public class GithubClientConfig {
 
     @Bean
     public GitHubClient gitHubApiClient() {
-
-        System.out.println(properties.url());
-
+        log.info("properties url : {] ", properties.url());
         return HttpServiceProxyFactory
             .builderFor(WebClientAdapter.create(createGitHubWebClient()))
             .build()

--- a/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(500, "찾는 회원이 존재하지 않습니다"),
     REDIS_PUBLISH_ERROR(500, "레디스 이벤트 발행 과정에서 문제가 생겼습니다"),
     REDIS_SUBSCRIBE_ERROR(500, "레디스 이벤트 수신 과정에서 문제가 생겼습니다"),
+    GITHUB_CLIENT_ERROR(500, "깃허브 클라이언트 소통과정에 문제가 발생했습니다")
     ;
 
     private final int statusCode;


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-125

# 🔂 변경 내역
- 정우가 요청한 로그아웃 API오류 여부를 검토합니다.
- 잘못된 github URL로 요청할 경우에 에러코드를 구분합니다.


# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 깃허브 클라이언트 오류를 위한 새로운 에러 코드가 추가되었습니다.
  * GithubRepoUrl 클래스에 url 필드가 추가되었습니다.

* **버그 수정**
  * 깃허브 API 오류 처리 시, 404 및 기타 오류에 대해 더 구체적인 예외가 반환됩니다.
  * Repository API 문서에서 불필요한 요청 본문 설명이 제거되어 실제 동작과 일치하도록 수정되었습니다.

* **개선 사항**
  * 로그 출력이 표준 출력에서 로깅 방식으로 변경되었습니다.
  * 일부 Swagger 문서의 파라미터 위치 및 이름이 수정되었습니다.
  * 저장소 저장 기능에 트랜잭션 처리가 추가되었습니다.

* **기타**
  * gss-github-client 모듈에 gss-common 모듈 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->