### PR TITLE
[GSS-124] PR 조회 시 PR 링크도 같이 반환되도록 조정

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestDetailReadResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestDetailReadResponse.java
@@ -28,6 +28,10 @@ public record PullRequestDetailReadResponse(
         RecordStatus recordStatus,
 
         @NotNull
+        @Schema(description = "풀 리퀘스트 url", example = "https://github.com/aaa/bbb/pull/4")
+        String pullRequestUrl,
+
+        @NotNull
         @Schema(description = "머지 시각", example = "2025-07-07T13:45:30")
         LocalDateTime mergedAt,
 
@@ -49,7 +53,7 @@ public record PullRequestDetailReadResponse(
             List<String> categories,
             List<QuestionAnswer> prQuestions
     ) {
-        List<QuestionAnswerResponse> questionAnswerRespons = prQuestions.stream()
+        List<QuestionAnswerResponse> questionAnswerResponse = prQuestions.stream()
                 .map(QuestionAnswerResponse::new)
                 .toList();
         return new PullRequestDetailReadResponse(
@@ -57,10 +61,11 @@ public record PullRequestDetailReadResponse(
                 pullRequest.getTitle(),
                 pullRequest.getTag(),
                 pullRequest.getRecordStatus(),
+                pullRequest.getPullRequestUrl(),
                 pullRequest.getMergedAt(),
                 pullRequest.getSummary(),
                 categories,
-                questionAnswerRespons
+                questionAnswerResponse
         );
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestReadResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestReadResponse.java
@@ -27,6 +27,10 @@ public record PullRequestReadResponse(
         RecordStatus recordStatus,
 
         @NotNull
+        @Schema(description = "풀 리퀘스트 url", example = "https://github.com/aaa/bbb/pull/4")
+        String pullRequestUrl,
+
+        @NotNull
         @Schema(description = "머지 시각", example = "2025-07-07T13:45:30")
         LocalDateTime mergedAt,
 
@@ -53,6 +57,7 @@ public record PullRequestReadResponse(
                 pullRequest.getTitle(),
                 pullRequest.getTag(),
                 pullRequest.getRecordStatus(),
+                pullRequest.getPullRequestUrl(),
                 pullRequest.getMergedAt(),
                 pullRequest.getSummary(),
                 categories,

--- a/gss-api-app/src/main/java/com/devoops/event/listener/PrAnalyzeListener.java
+++ b/gss-api-app/src/main/java/com/devoops/event/listener/PrAnalyzeListener.java
@@ -39,6 +39,7 @@ public class PrAnalyzeListener {
         return new AppWebhookEventRequest(
                 true,
                 githubPrResponse.id(),
+                githubPrResponse.url(),
                 githubPrResponse.diffUrl(),
                 githubPrResponse.title(),
                 githubPrResponse.getDescription(),

--- a/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
+++ b/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
@@ -30,6 +30,7 @@ public class FakeGithubClient implements GitHubClient {
     public List<GithubPrResponse> getPullRequests(String authorization, String owner, String repo, String state, long perPage, long page) {
         return List.of(new GithubPrResponse(
                 1L,
+                "https://api.github.com/repos/owner/repo/pulls/38",
                 "title",
                 "body",
                 new GithubPrResponse.User(1L, "login"),

--- a/gss-client/gss-github-client/src/main/java/com/devoops/config/GithubClientConfig.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/config/GithubClientConfig.java
@@ -29,7 +29,7 @@ public class GithubClientConfig {
 
     @Bean
     public GitHubClient gitHubApiClient() {
-        log.info("properties url : {] ", properties.url());
+        log.info("properties url : {} ", properties.url());
         return HttpServiceProxyFactory
             .builderFor(WebClientAdapter.create(createGitHubWebClient()))
             .build()

--- a/gss-client/gss-github-client/src/main/java/com/devoops/dto/response/GithubPrResponse.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/dto/response/GithubPrResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record GithubPrResponse(
         long id,
+        String url,
         String title,
         String body,
         User user,

--- a/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
+++ b/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
@@ -12,6 +12,7 @@ public record PullRequestCreateCommand(
     String description,
     String summary,
     String summaryDetail,
+    String pullRequestUrl,
     long externalId,
     RecordStatus recordStatus,
     LocalDateTime mergedAt,
@@ -25,11 +26,12 @@ public record PullRequestCreateCommand(
             String description,
             String summary,
             String summaryDetail,
+            String pullRequestUrl,
             long externalId,
             String tag,
             LocalDateTime mergedAt
     ) {
-        this(repositoryId, userId, title, description, summary, summaryDetail, externalId, RecordStatus.PENDING, mergedAt, tag);
+        this(repositoryId, userId, title, description, summary, summaryDetail, pullRequestUrl, externalId, RecordStatus.PENDING, mergedAt, tag);
     }
 
     public PullRequest toDomainEntity() {
@@ -41,6 +43,7 @@ public record PullRequestCreateCommand(
             description,
             summary,
             summaryDetail,
+            pullRequestUrl,
             externalId,
             RecordStatus.PENDING,
             mergedAt,

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/PullRequest.java
@@ -16,6 +16,7 @@ public class PullRequest {
     private final String description;
     private final String summary;
     private final String summaryDetail;
+    private final String pullRequestUrl;
     private final long externalId;
     private final RecordStatus recordStatus;
     private final LocalDateTime mergedAt;

--- a/gss-domain/src/main/java/com/devoops/dto/AppWebhookEventRequest.java
+++ b/gss-domain/src/main/java/com/devoops/dto/AppWebhookEventRequest.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record AppWebhookEventRequest(
         Boolean isMerged,
         long pullRequestId,
+        String pullRequestUrl,
         String diffUrl,
         String title,
         String description,
@@ -14,4 +15,7 @@ public record AppWebhookEventRequest(
         LocalDateTime mergedAt
 ) {
 
+    public GithubPRUrl getParsedUrl() {
+        return new GithubPRUrl(pullRequestUrl);
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/dto/GithubPRUrl.java
+++ b/gss-domain/src/main/java/com/devoops/dto/GithubPRUrl.java
@@ -16,7 +16,8 @@ public class GithubPRUrl {
 
     private String parsed(String url) {
         if(url.startsWith(GITHUB_REPO_API_URL)) {
-            return url.replace(GITHUB_REPO_API_URL, GITHUB_REPO_URL);
+            String replaceApiPrefix = url.replace(GITHUB_REPO_API_URL, GITHUB_REPO_URL);
+            return replaceApiPrefix.replaceFirst("/pulls/(\\d+)$", "/pull/$1");
         }
         return url;
     }

--- a/gss-domain/src/main/java/com/devoops/dto/GithubPRUrl.java
+++ b/gss-domain/src/main/java/com/devoops/dto/GithubPRUrl.java
@@ -1,0 +1,23 @@
+package com.devoops.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GithubPRUrl {
+
+    private static final String GITHUB_REPO_API_URL = "https://api.github.com/repos";
+    private static final String GITHUB_REPO_URL = "https://github.com";
+
+    private final String value;
+
+    public GithubPRUrl(String value) {
+        this.value = parsed(value);
+    }
+
+    private String parsed(String url) {
+        if(url.startsWith(GITHUB_REPO_API_URL)) {
+            return url.replace(GITHUB_REPO_API_URL, GITHUB_REPO_URL);
+        }
+        return url;
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/PullRequestEntity.java
@@ -54,6 +54,9 @@ public class PullRequestEntity extends BaseTimeEntity {
     private long githubPullRequestId;
 
     @NotNull
+    private String pullRequestUrl;
+
+    @NotNull
     @Enumerated(EnumType.STRING)
     private RecordStatus recordStatus;
 
@@ -71,6 +74,7 @@ public class PullRequestEntity extends BaseTimeEntity {
                 pullRequest.getSummary(),
                 pullRequest.getSummaryDetail(),
                 pullRequest.getExternalId(),
+                pullRequest.getPullRequestUrl(),
                 pullRequest.getRecordStatus(),
                 pullRequest.getMergedAt()
         );
@@ -94,6 +98,7 @@ public class PullRequestEntity extends BaseTimeEntity {
                 this.description,
                 this.summary,
                 this.summaryDetail,
+                this.pullRequestUrl,
                 this.githubPullRequestId,
                 this.recordStatus,
                 this.mergedAt,

--- a/gss-domain/src/test/java/com/devoops/dto/GithubPRUrlTest.java
+++ b/gss-domain/src/test/java/com/devoops/dto/GithubPRUrlTest.java
@@ -1,0 +1,24 @@
+package com.devoops.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GithubPRUrlTest {
+
+    @Nested
+    class Parsed {
+
+        @Test
+        void 웹_상으로_이동가능한_풀_리퀘스트_url을_가진다() {
+            String raw = "https://api.github.com/repos/owner/repo/pulls/38";
+            String parsed = "https://github.com/owner/repo/pull/38";
+
+            GithubPRUrl url = new GithubPRUrl(raw);
+
+            assertThat(url.getValue()).isEqualTo(parsed);
+        }
+    }
+
+}

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/PullRequestGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/PullRequestGenerator.java
@@ -24,6 +24,7 @@ public class PullRequestGenerator {
             "description",
             "summary",
             "summaryDetail",
+            "https://github.com/owner/repo/pull/2",
             1L,
             status,
             mergedAt,

--- a/gss-mcp-app/src/main/java/com/devoops/controller/webhook/WebhookController.java
+++ b/gss-mcp-app/src/main/java/com/devoops/controller/webhook/WebhookController.java
@@ -33,6 +33,7 @@ public class WebhookController {
         return new AppWebhookEventRequest(
                 request.isMerged(),
                 request.getExternalId(),
+                request.getPullRequestUrl(),
                 request.getPullRequestDiffUrl(),
                 request.getTitle(),
                 request.getDescription(),

--- a/gss-mcp-app/src/main/java/com/devoops/dto/request/GitHubWebhookEventRequest.java
+++ b/gss-mcp-app/src/main/java/com/devoops/dto/request/GitHubWebhookEventRequest.java
@@ -52,6 +52,10 @@ public record GitHubWebhookEventRequest(
     ) {
     }
 
+    public String getPullRequestUrl() {
+        return pullRequest.url;
+    }
+
     public long getRepositoryId() {
         return repository.id;
     }

--- a/gss-mcp-app/src/main/java/com/devoops/service/webhook/WebhookFacadeService.java
+++ b/gss-mcp-app/src/main/java/com/devoops/service/webhook/WebhookFacadeService.java
@@ -94,6 +94,7 @@ public class WebhookFacadeService {
                 appWebhookEventRequest.description(),
                 adaptedAnalyzePrResponse.summary(),
                 adaptedAnalyzePrResponse.detailSummary(),
+                appWebhookEventRequest.getParsedUrl().getValue(),
                 appWebhookEventRequest.pullRequestId(),
                 appWebhookEventRequest.label(),
                 appWebhookEventRequest.mergedAt()

--- a/gss-mcp-app/src/test/java/com/devoops/service/webhook/WebhookFacadeServiceTest.java
+++ b/gss-mcp-app/src/test/java/com/devoops/service/webhook/WebhookFacadeServiceTest.java
@@ -57,6 +57,7 @@ class WebhookFacadeServiceTest extends BaseMcpTest {
         return new AppWebhookEventRequest(
                 request.isMerged(),
                 request.getExternalId(),
+                request.getPullRequestUrl(),
                 request.getPullRequestDiffUrl(),
                 request.getTitle(),
                 request.getDescription(),


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-124

# 🔂 변경 내역

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 풀 리퀘스트 URL 정보를 여러 화면 및 응답에 추가하여, 풀 리퀘스트의 웹 링크를 직접 확인할 수 있습니다.
  * GitHub API 형식의 풀 리퀘스트 URL을 웹에서 접근 가능한 표준 GitHub URL로 변환하는 기능이 도입되었습니다.

* **버그 수정**
  * 일부 로그 메시지의 포맷팅 오류가 수정되었습니다.

* **테스트**
  * GitHub 풀 리퀘스트 URL 변환 로직에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->