### PR TITLE
[GSS-126] 레포지토리 삭제 로직 추가

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/controller/docs/RepositoryControllerSwagger.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/docs/RepositoryControllerSwagger.java
@@ -103,4 +103,15 @@ public interface RepositoryControllerSwagger {
             }
     )
     ResponseEntity<MyRepositoriesResponse> getMyRepositories(@Parameter(hidden = true) User user);
+
+    @Operation(
+            summary = "레포지토리 삭제",
+            responses = {@ApiResponse(
+                    responseCode = "204",
+                    description = "나의 레포지토리 삭제 성공")}
+    )
+    ResponseEntity<Void> deleteRepositories(
+            @Parameter(hidden = true) User user,
+            long repositoryId
+    );
 }

--- a/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
@@ -10,14 +10,18 @@ import com.devoops.dto.response.MyRepositoriesResponse;
 import com.devoops.dto.response.RepositoryPullRequestResponses;
 import com.devoops.dto.response.RepositorySaveResponse;
 import com.devoops.service.facade.RepositoryFacadeService;
-import com.devoops.service.repository.RepositoryService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +29,6 @@ import java.util.List;
 public class RepositoryController implements RepositoryControllerSwagger {
 
     private final RepositoryFacadeService repositoryFacadeService;
-    private final RepositoryService repositoryService;
 
     @Override
     @GetMapping("/{repositoryId}/pull-requests")
@@ -35,7 +38,8 @@ public class RepositoryController implements RepositoryControllerSwagger {
             @RequestParam(name = "size") int size,
             @RequestParam(name = "page") int page
     ) {
-        PullRequests pullRequests = repositoryFacadeService.findAllPullRequestsByRepository(user, repositoryId, size, page);
+        PullRequests pullRequests = repositoryFacadeService.findAllPullRequestsByRepository(user, repositoryId, size,
+                page);
         RepositoryPullRequestResponses response = RepositoryPullRequestResponses.from(pullRequests);
         return ResponseEntity.ok(response);
     }
@@ -67,8 +71,14 @@ public class RepositoryController implements RepositoryControllerSwagger {
     @Override
     @GetMapping("/me")
     public ResponseEntity<MyRepositoriesResponse> getMyRepositories(@AuthUser User user) {
-        List<GithubRepository> repositories = repositoryService.getMyRepositories(user);
+        List<GithubRepository> repositories = repositoryFacadeService.findMyRepositories(user);
         return ResponseEntity.ok(MyRepositoriesResponse.from(repositories));
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteRepositories(User user, long repositoryId) {
+        repositoryFacadeService.deleteRepository(user, repositoryId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
@@ -15,6 +15,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -76,7 +77,11 @@ public class RepositoryController implements RepositoryControllerSwagger {
     }
 
     @Override
-    public ResponseEntity<Void> deleteRepositories(User user, long repositoryId) {
+    @DeleteMapping("/{repositoryId}")
+    public ResponseEntity<Void> deleteRepositories(
+            User user,
+            @PathVariable(name = "repositoryId") long repositoryId
+    ) {
         repositoryFacadeService.deleteRepository(user, repositoryId);
         return ResponseEntity.noContent().build();
     }

--- a/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
+++ b/gss-api-app/src/main/java/com/devoops/controller/repository/RepositoryController.java
@@ -79,7 +79,7 @@ public class RepositoryController implements RepositoryControllerSwagger {
     @Override
     @DeleteMapping("/{repositoryId}")
     public ResponseEntity<Void> deleteRepositories(
-            User user,
+            @AuthUser User user,
             @PathVariable(name = "repositoryId") long repositoryId
     ) {
         repositoryFacadeService.deleteRepository(user, repositoryId);

--- a/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
@@ -3,15 +3,19 @@ package com.devoops.service;
 import com.devoops.client.GitHubClient;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.GithubToken;
+import com.devoops.domain.entity.github.GithubWebhook;
 import com.devoops.domain.entity.user.User;
 import com.devoops.domain.repository.github.GithubRepoDomainRepository;
 import com.devoops.domain.repository.github.GithubTokenDomainRepository;
+import com.devoops.domain.repository.github.GithubWebhookDomainRepository;
 import com.devoops.dto.request.GitHubWebhookRequest;
 import com.devoops.dto.request.GithubRepoUrl;
 import com.devoops.dto.response.GithubPrResponse;
 import com.devoops.dto.response.GithubRepoInfoResponse;
+import com.devoops.dto.response.WebHookCreateResponse;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
+import com.devoops.jpa.repository.github.GithubWebHookDomainRepositoryImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +29,7 @@ public class GitHubService {
     private static final int MAX_USER_PR_LIMIT = 3;
     private static final int MAX_PER_PAGE_PULL_REQUEST = 10;
     private static final String REQUEST_PULL_REQUEST_STATUS = "closed";
+    private final GithubWebHookDomainRepositoryImpl githubWebHookDomainRepositoryImpl;
 
     @Value("${dev-oops.mcp.webhook-url}")
     private String mcpWebhookUrl;
@@ -32,19 +37,25 @@ public class GitHubService {
     private final GitHubClient gitHubClient;
     private final GithubRepoDomainRepository githubRepoDomainRepository;
     private final GithubTokenDomainRepository githubTokenDomainRepository;
+    private final GithubWebhookDomainRepository githubWebhookDomainRepository;
 
     public void registerWebhook(User user, long repositoryId) {
 
         GithubRepository githubRepository = githubRepoDomainRepository.findByIdAndUserId(repositoryId, user.getId());
         GithubToken githubToken = githubTokenDomainRepository.findByUserId(user)
                 .orElseThrow(() -> new GssException(ErrorCode.NO_RESOURCE_FOUND));
+        createWebHook(githubToken, githubRepository);
+    }
 
-        gitHubClient.createWebhook(
-                BEARER_PREFIX + githubToken.getToken(),
-                githubRepository.getOwner(),
-                githubRepository.getName(),
+    private GithubWebhook createWebHook(GithubToken token, GithubRepository repo) {
+        WebHookCreateResponse webHookCreateResponse = gitHubClient.createWebhook(
+                BEARER_PREFIX + token.getToken(),
+                repo.getOwner(),
+                repo.getName(),
                 GitHubWebhookRequest.ofPullRequestEvent(mcpWebhookUrl)
         );
+        GithubWebhook webhook = new GithubWebhook(webHookCreateResponse.id(), repo.getId());
+        return githubWebhookDomainRepository.save(webhook);
     }
 
     public List<GithubPrResponse> getUserPullRequests(

--- a/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,6 @@ public class GitHubService {
     private static final int MAX_USER_PR_LIMIT = 3;
     private static final int MAX_PER_PAGE_PULL_REQUEST = 10;
     private static final String REQUEST_PULL_REQUEST_STATUS = "closed";
-    private final GithubWebHookDomainRepositoryImpl githubWebHookDomainRepositoryImpl;
 
     @Value("${dev-oops.mcp.webhook-url}")
     private String mcpWebhookUrl;
@@ -71,7 +71,6 @@ public class GitHubService {
                 MAX_PER_PAGE_PULL_REQUEST,
                 1
         );
-        System.out.println(closedPullRequests);
         return closedPullRequests.stream()
                 .filter(pr -> pr.isUserPr(user.getProviderId()))
                 .limit(MAX_USER_PR_LIMIT)
@@ -84,5 +83,20 @@ public class GitHubService {
                 repoUrl.getOwner(),
                 repoUrl.getRepoName()
         );
+    }
+
+    @Transactional
+    public void deleteWebhook(User user, long repositoryId) {
+        GithubRepository repo = githubRepoDomainRepository.findByIdAndUserId(repositoryId, user.getId());
+        GithubToken githubToken = githubTokenDomainRepository.findByUserId(user)
+                .orElseThrow(() -> new GssException(ErrorCode.NO_RESOURCE_FOUND));
+        GithubWebhook webhook = githubWebhookDomainRepository.findByRepositoryId(repo.getId());
+        gitHubClient.deleteWebhook(
+                BEARER_PREFIX + githubToken.getToken(),
+                repo.getOwner(),
+                repo.getName(),
+                webhook.getExternalId()
+        );
+        githubWebhookDomainRepository.deleteById(webhook.getId());
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,6 @@ public class GitHubService {
     private static final int MAX_USER_PR_LIMIT = 3;
     private static final int MAX_PER_PAGE_PULL_REQUEST = 10;
     private static final String REQUEST_PULL_REQUEST_STATUS = "closed";
-    private final GithubWebHookDomainRepositoryImpl githubWebHookDomainRepositoryImpl;
 
     @Value("${dev-oops.mcp.webhook-url}")
     private String mcpWebhookUrl;
@@ -84,5 +84,20 @@ public class GitHubService {
                 repoUrl.getOwner(),
                 repoUrl.getRepoName()
         );
+    }
+
+    @Transactional
+    public void deleteWebhook(User user, long repositoryId) {
+        GithubRepository repo = githubRepoDomainRepository.findByIdAndUserId(repositoryId, user.getId());
+        GithubToken githubToken = githubTokenDomainRepository.findByUserId(user)
+                .orElseThrow(() -> new GssException(ErrorCode.NO_RESOURCE_FOUND));
+        GithubWebhook webhook = githubWebhookDomainRepository.findByRepositoryId(repo.getId());
+        gitHubClient.deleteWebhook(
+                BEARER_PREFIX + githubToken.getToken(),
+                repo.getOwner(),
+                repo.getName(),
+                webhook.getExternalId()
+        );
+        githubWebhookDomainRepository.deleteById(webhook.getId());
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -64,6 +64,5 @@ public class RepositoryFacadeService {
     public void deleteRepository(User user, long repositoryId) {
         gitHubService.deleteWebhook(user, repositoryId);
         repositoryService.delete(user, repositoryId);
-        gitHubService.deleteWebhook(user, repositoryId);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -62,7 +62,7 @@ public class RepositoryFacadeService {
 
     @Transactional
     public void deleteRepository(User user, long repositoryId) {
-        repositoryService.delete(user, repositoryId);
         gitHubService.deleteWebhook(user, repositoryId);
+        repositoryService.delete(user, repositoryId);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -63,5 +63,6 @@ public class RepositoryFacadeService {
     @Transactional
     public void deleteRepository(User user, long repositoryId) {
         repositoryService.delete(user, repositoryId);
+        gitHubService.deleteWebhook(user, repositoryId);
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -12,6 +12,7 @@ import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.event.AnalyzeMyPrEvent;
 import com.devoops.service.GitHubService;
 import com.devoops.service.repository.RepositoryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -53,5 +54,14 @@ public class RepositoryFacadeService {
 
     public PullRequests findAllPullRequests(User user, int size, int page) {
         return repositoryService.getPullRequests(user, size, page);
+    }
+
+    public List<GithubRepository> findMyRepositories(User user) {
+        return repositoryService.getMyRepositories(user);
+    }
+
+    @Transactional
+    public void deleteRepository(User user, long repositoryId) {
+        repositoryService.delete(user, repositoryId);
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/BaseServiceTest.java
@@ -6,6 +6,7 @@ import com.devoops.generator.GithubRepoGenerator;
 import com.devoops.generator.PullRequestGenerator;
 import com.devoops.generator.QuestionGenerator;
 import com.devoops.generator.UserGenerator;
+import com.devoops.generator.WebhookGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,5 +36,8 @@ public abstract class BaseServiceTest {
 
     @Autowired
     protected AnswerRankingGenerator answerRankingGenerator;
+
+    @Autowired
+    protected WebhookGenerator webhookGenerator;
 }
 

--- a/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
+++ b/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
@@ -7,6 +7,7 @@ import com.devoops.dto.response.GithubPrResponse.Label;
 import com.devoops.dto.response.GithubPrResponse.Repository;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
+import com.devoops.dto.response.WebHookCreateResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.context.annotation.Primary;
@@ -42,6 +43,7 @@ public class FakeGithubClient implements GitHubClient {
     }
 
     @Override
-    public void createWebhook(String authorization, String owner, String repo, GitHubWebhookRequest request) {
+    public WebHookCreateResponse createWebhook(String authorization, String owner, String repo, GitHubWebhookRequest request) {
+        return new WebHookCreateResponse(101L);
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
+++ b/gss-api-app/src/test/java/com/devoops/fake/FakeGithubClient.java
@@ -46,4 +46,9 @@ public class FakeGithubClient implements GitHubClient {
     public WebHookCreateResponse createWebhook(String authorization, String owner, String repo, GitHubWebhookRequest request) {
         return new WebHookCreateResponse(101L);
     }
+
+    @Override
+    public void deleteWebhook(String authorization, String owner, String repo, long hookId) {
+
+    }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/GitHubServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/GitHubServiceTest.java
@@ -1,0 +1,47 @@
+package com.devoops.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.devoops.BaseServiceTest;
+import com.devoops.client.GitHubClient;
+import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.GithubWebhook;
+import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.GithubWebhookDomainRepository;
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class GitHubServiceTest extends BaseServiceTest {
+
+    @MockitoBean
+    private GitHubClient gitHubClient;
+
+    @Autowired
+    private GitHubService gitHubService;
+
+    @Autowired
+    private GithubWebhookDomainRepository webhookDomainRepository;
+
+
+    @Nested
+    class DeleteWebHook {
+
+        @Test
+        void 웹_훅을_삭제_할_수_있다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            GithubWebhook webhook = webhookGenerator.generate(user, repo);
+
+            gitHubService.deleteWebhook(user, repo.getId());
+
+            assertThatThrownBy(() -> webhookDomainRepository.findByRepositoryId(repo.getId()))
+                    .isInstanceOf(GssException.class)
+                    .hasMessage(ErrorCode.WEBHOOK_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -9,29 +9,14 @@ import static org.mockito.Mockito.times;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.client.GitHubClient;
-import com.devoops.domain.entity.github.Answer;
-import com.devoops.domain.entity.github.AnswerRanking;
-import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.entity.github.GithubRepository;
-import com.devoops.domain.entity.github.PullRequest;
-import com.devoops.domain.entity.github.PullRequests;
-import com.devoops.domain.entity.github.Question;
-import com.devoops.domain.entity.github.QuestionAnswer;
-import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
-import com.devoops.domain.repository.github.AnswerDomainRepository;
-import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
 import com.devoops.domain.repository.github.GithubRepoDomainRepository;
-import com.devoops.domain.repository.github.PullRequestDomainRepository;
-import com.devoops.domain.repository.github.QuestionDomainRepository;
 import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
-import com.devoops.generator.AnswerRankingGenerator;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,18 +27,6 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
 
     @Autowired
     private GithubRepoDomainRepository githubRepoDomainRepository;
-
-    @Autowired
-    private PullRequestDomainRepository pullRequestDomainRepository;
-
-    @Autowired
-    private QuestionDomainRepository questionDomainRepository;
-
-    @Autowired
-    private AnswerRankingDomainRepository answerRankingDomainRepository;
-
-    @Autowired
-    private AnswerDomainRepository answerDomainRepository;
 
     @Autowired
     private RepositoryFacadeService repositoryFacadeService;
@@ -97,44 +70,6 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
             assertThatThrownBy(() -> repositoryFacadeService.save(request, user))
                     .isInstanceOf(GssException.class)
                     .hasMessage(ErrorCode.ALREADY_SAVED_REPOSITORY.getMessage());
-        }
-    }
-
-    @Nested
-    class Delete {
-
-        @Test
-        void 레포지토리를_삭제할_수_있다() {
-            User user = userGenerator.generate("김건우");
-            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
-            Question question1 = questionGenerator.generate(pr1, "질문1");
-            Question question2 = questionGenerator.generate(pr2, "질문2");
-            Answer answer1 = answerGenerator.generate(question1, "answer1");
-            Answer answer2 = answerGenerator.generate(question2, "answer2");
-            AnswerRanking answerRanking1 = answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
-            AnswerRanking answerRanking2 = answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
-
-            repositoryFacadeService.deleteRepository(user, repo.getId());
-
-            boolean exists = githubRepoDomainRepository.existsByIdAndUserId(repo.getId(), user.getId());
-            PullRequests repositoryPrs = pullRequestDomainRepository.findByRepositoryId(repo.getId());
-            List<QuestionAnswer> pr1Questions = questionDomainRepository.findAllPrQuestions(pr1.getId());
-            List<QuestionAnswer> pr2Questions = questionDomainRepository.findAllPrQuestions(pr2.getId());
-            AnswerRankings userAnswerRankings = answerRankingDomainRepository.findAllByUserId(user.getId());
-            long pr1AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr1.getId());
-            long pr2AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr2.getId());
-
-            assertAll(
-                    () -> assertThat(exists).isFalse(),
-                    () -> assertThat(repositoryPrs.getValues()).isEmpty(),
-                    () -> assertThat(pr1Questions).isEmpty(),
-                    () -> assertThat(pr2Questions).isEmpty(),
-                    () -> assertThat(userAnswerRankings.getRankings()).isEmpty(),
-                    () -> assertThat(pr1AnswerCount).isZero(),
-                    () -> assertThat(pr2AnswerCount).isZero()
-            );
         }
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -2,22 +2,36 @@ package com.devoops.service.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.client.GitHubClient;
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.PullRequests;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.entity.github.QuestionAnswer;
+import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
 import com.devoops.domain.repository.github.GithubRepoDomainRepository;
+import com.devoops.domain.repository.github.PullRequestDomainRepository;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
 import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
+import com.devoops.generator.AnswerRankingGenerator;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -28,6 +42,18 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
 
     @Autowired
     private GithubRepoDomainRepository githubRepoDomainRepository;
+
+    @Autowired
+    private PullRequestDomainRepository pullRequestDomainRepository;
+
+    @Autowired
+    private QuestionDomainRepository questionDomainRepository;
+
+    @Autowired
+    private AnswerRankingDomainRepository answerRankingDomainRepository;
+
+    @Autowired
+    private AnswerDomainRepository answerDomainRepository;
 
     @Autowired
     private RepositoryFacadeService repositoryFacadeService;
@@ -42,7 +68,8 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         void 레포지토리를_저장하고_웹훅을_심는다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
-            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl", new OwnerResponse("김건우"));
+            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
+                    new OwnerResponse("김건우"));
             Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
                     .thenReturn(mockResponse);
 
@@ -61,7 +88,8 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         void 레포지토리를_중복_저장할_수_없다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
-            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl", new OwnerResponse("김건우"));
+            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
+                    new OwnerResponse("김건우"));
             Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
                     .thenReturn(mockResponse);
             repositoryFacadeService.save(request, user);
@@ -69,6 +97,44 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
             assertThatThrownBy(() -> repositoryFacadeService.save(request, user))
                     .isInstanceOf(GssException.class)
                     .hasMessage(ErrorCode.ALREADY_SAVED_REPOSITORY.getMessage());
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void 레포지토리를_삭제할_수_있다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pr1, "질문1");
+            Question question2 = questionGenerator.generate(pr2, "질문2");
+            Answer answer1 = answerGenerator.generate(question1, "answer1");
+            Answer answer2 = answerGenerator.generate(question2, "answer2");
+            AnswerRanking answerRanking1 = answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
+            AnswerRanking answerRanking2 = answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
+
+            repositoryFacadeService.deleteRepository(user, repo.getId());
+
+            boolean exists = githubRepoDomainRepository.existsByIdAndUserId(repo.getId(), user.getId());
+            PullRequests repositoryPrs = pullRequestDomainRepository.findByRepositoryId(repo.getId());
+            List<QuestionAnswer> pr1Questions = questionDomainRepository.findAllPrQuestions(pr1.getId());
+            List<QuestionAnswer> pr2Questions = questionDomainRepository.findAllPrQuestions(pr2.getId());
+            AnswerRankings userAnswerRankings = answerRankingDomainRepository.findAllByUserId(user.getId());
+            long pr1AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr1.getId());
+            long pr2AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr2.getId());
+
+            assertAll(
+                    () -> assertThat(exists).isFalse(),
+                    () -> assertThat(repositoryPrs.getValues()).isEmpty(),
+                    () -> assertThat(pr1Questions).isEmpty(),
+                    () -> assertThat(pr2Questions).isEmpty(),
+                    () -> assertThat(userAnswerRankings.getRankings()).isEmpty(),
+                    () -> assertThat(pr1AnswerCount).isZero(),
+                    () -> assertThat(pr2AnswerCount).isZero()
+            );
         }
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -15,6 +15,7 @@ import com.devoops.domain.repository.github.GithubRepoDomainRepository;
 import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
+import com.devoops.dto.response.WebHookCreateResponse;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import org.junit.jupiter.api.Nested;
@@ -41,10 +42,7 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         void 레포지토리를_저장하고_웹훅을_심는다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
-            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
-                    new OwnerResponse("김건우"));
-            Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
-                    .thenReturn(mockResponse);
+            mockingGithubClient();
 
             GithubRepository savedRepository = repositoryFacadeService.save(request, user);
 
@@ -61,15 +59,23 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         void 레포지토리를_중복_저장할_수_없다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
-            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
-                    new OwnerResponse("김건우"));
-            Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
-                    .thenReturn(mockResponse);
+            mockingGithubClient();
+
             repositoryFacadeService.save(request, user);
 
             assertThatThrownBy(() -> repositoryFacadeService.save(request, user))
                     .isInstanceOf(GssException.class)
                     .hasMessage(ErrorCode.ALREADY_SAVED_REPOSITORY.getMessage());
+        }
+
+        private void mockingGithubClient() {
+            GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
+                    new OwnerResponse("김건우"));
+            WebHookCreateResponse mockWebHookCreateResponse = new WebHookCreateResponse(123);
+            Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
+                    .thenReturn(mockResponse);
+            Mockito.when(gitHubClient.createWebhook(any(), any(), any(), any()))
+                    .thenReturn(mockWebHookCreateResponse);
         }
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
@@ -5,10 +5,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseServiceTest;
+import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.AnswerRanking;
+import com.devoops.domain.entity.github.AnswerRankings;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.PullRequests;
+import com.devoops.domain.entity.github.Question;
+import com.devoops.domain.entity.github.QuestionAnswer;
 import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
+import com.devoops.domain.repository.github.GithubRepoDomainRepository;
+import com.devoops.domain.repository.github.PullRequestDomainRepository;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import java.time.LocalDateTime;
@@ -21,6 +32,21 @@ class RepositoryServiceTest extends BaseServiceTest {
 
     @Autowired
     private RepositoryService repositoryService;
+
+    @Autowired
+    private GithubRepoDomainRepository githubRepoDomainRepository;
+
+    @Autowired
+    private PullRequestDomainRepository pullRequestDomainRepository;
+
+    @Autowired
+    private QuestionDomainRepository questionDomainRepository;
+
+    @Autowired
+    private AnswerRankingDomainRepository answerRankingDomainRepository;
+
+    @Autowired
+    private AnswerDomainRepository answerDomainRepository;
 
     @Nested
     class getRepositoryPullRequestsByRepository {
@@ -147,6 +173,44 @@ class RepositoryServiceTest extends BaseServiceTest {
             assertAll(
                     () -> assertThat(pageOneIds).containsOnly(nowPr.getId(), oneMinutesAgoPR.getId()),
                     () -> assertThat(pageTwoIds).containsOnly(threeMinutesAgoPR.getId(), fiveMinutesAgoPR.getId())
+            );
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void 레포지토리를_삭제할_수_있다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
+            Question question1 = questionGenerator.generate(pr1, "질문1");
+            Question question2 = questionGenerator.generate(pr2, "질문2");
+            Answer answer1 = answerGenerator.generate(question1, "answer1");
+            Answer answer2 = answerGenerator.generate(question2, "answer2");
+            AnswerRanking answerRanking1 = answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
+            AnswerRanking answerRanking2 = answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
+
+            repositoryService.delete(user, repo.getId());
+
+            boolean exists = githubRepoDomainRepository.existsByIdAndUserId(repo.getId(), user.getId());
+            PullRequests repositoryPrs = pullRequestDomainRepository.findByRepositoryId(repo.getId());
+            List<QuestionAnswer> pr1Questions = questionDomainRepository.findAllPrQuestions(pr1.getId());
+            List<QuestionAnswer> pr2Questions = questionDomainRepository.findAllPrQuestions(pr2.getId());
+            AnswerRankings userAnswerRankings = answerRankingDomainRepository.findAllByUserId(user.getId());
+            long pr1AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr1.getId());
+            long pr2AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr2.getId());
+
+            assertAll(
+                    () -> assertThat(exists).isFalse(),
+                    () -> assertThat(repositoryPrs.getValues()).isEmpty(),
+                    () -> assertThat(pr1Questions).isEmpty(),
+                    () -> assertThat(pr2Questions).isEmpty(),
+                    () -> assertThat(userAnswerRankings.getRankings()).isEmpty(),
+                    () -> assertThat(pr1AnswerCount).isZero(),
+                    () -> assertThat(pr2AnswerCount).isZero()
             );
         }
     }

--- a/gss-client/gss-github-client/src/main/java/com/devoops/client/GitHubClient.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/client/GitHubClient.java
@@ -3,6 +3,7 @@ package com.devoops.client;
 import com.devoops.dto.request.GitHubWebhookRequest;
 import com.devoops.dto.response.GithubPrResponse;
 import com.devoops.dto.response.GithubRepoInfoResponse;
+import com.devoops.dto.response.WebHookCreateResponse;
 import java.util.List;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -66,7 +67,7 @@ public interface GitHubClient {
      * </a>
      */
     @PostExchange(url = "/repos/{owner}/{repo}/hooks")
-    void createWebhook(
+    WebHookCreateResponse createWebhook(
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
         @PathVariable("owner") String owner,
         @PathVariable("repo") String repo,

--- a/gss-client/gss-github-client/src/main/java/com/devoops/client/GitHubClient.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/client/GitHubClient.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.DeleteExchange;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
@@ -72,5 +73,23 @@ public interface GitHubClient {
         @PathVariable("owner") String owner,
         @PathVariable("repo") String repo,
         @RequestBody GitHubWebhookRequest request
+    );
+
+    /**
+     * GitHub 저장소에 Webhook을 삭제합니다.
+     *
+     * @param authorization Authorization 헤더 (예: Bearer 토큰)
+     * @param owner         저장소 소유자
+     * @param repo          저장소 이름
+     * @see <a href=https://docs.github.com/ko/rest/repos/webhooks?apiVersion=2022-11-28#delete-a-repository-webhook">
+     * GitHub 공식 문서 - Create a repository webhook
+     * </a>
+     */
+    @DeleteExchange(url = "/repos/{owner}/{repo}/hooks/{hookId}")
+    void deleteWebhook(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+            @PathVariable("owner") String owner,
+            @PathVariable("repo") String repo,
+            @PathVariable("hookId") long hookId
     );
 }

--- a/gss-client/gss-github-client/src/main/java/com/devoops/dto/response/WebHookCreateResponse.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/dto/response/WebHookCreateResponse.java
@@ -1,0 +1,7 @@
+package com.devoops.dto.response;
+
+public record WebHookCreateResponse(
+        long id
+) {
+
+}

--- a/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     PULL_REQUEST_NOT_FOUND(500, "찾는 풀 리퀘스트가 존재하지 않습니다"),
     QUESTION_NOT_FOUND(500, "찾는 질문이 존재하지 않습니다"),
     ANSWER_NOT_FOUND(500, "찾는 대답이 존재하지 않습니다"),
+    WEBHOOK_NOT_FOUND(500, "찾는 웹훅이 존재하지 않습니다"),
     ANSWER_RANKING_NOT_FOUND(500, "찾는 질문 랭킹이 존재하지 않습니다"),
     USER_NOT_FOUND(500, "찾는 회원이 존재하지 않습니다"),
     REDIS_PUBLISH_ERROR(500, "레디스 이벤트 발행 과정에서 문제가 생겼습니다"),

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubWebhook.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubWebhook.java
@@ -1,0 +1,12 @@
+package com.devoops.domain.entity.github;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GithubWebhook {
+
+    private final long id;
+    private final long repositoryId;
+}

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubWebhook.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubWebhook.java
@@ -7,6 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GithubWebhook {
 
-    private final long id;
+    private final Long id;
+    private final long externalId;
     private final long repositoryId;
+
+    public GithubWebhook(long externalId, long repositoryId) {
+        this(null, externalId, repositoryId);
+    }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerDomainRepository.java
@@ -1,6 +1,8 @@
 package com.devoops.domain.repository.github;
 
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Question;
+import java.util.List;
 
 public interface AnswerDomainRepository {
 
@@ -13,4 +15,6 @@ public interface AnswerDomainRepository {
     Answer updateById(long answerId, String content);
 
     void deleteById(long answerId);
+
+    void deleteAllInQuestions(List<Question> questions);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/AnswerRankingDomainRepository.java
@@ -3,6 +3,7 @@ package com.devoops.domain.repository.github;
 import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.entity.github.PullRequests;
 
 public interface AnswerRankingDomainRepository {
 
@@ -13,4 +14,6 @@ public interface AnswerRankingDomainRepository {
     AnswerRanking update(long pullRequestId, long questionId);
 
     void deleteById(long id);
+
+    void deleteAllInPullRequests(PullRequests pullRequests);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
@@ -17,4 +17,6 @@ public interface GithubRepoDomainRepository {
     boolean existsByExternalId(long externalId);
 
     GithubRepository findByExternalId(long externalId);
+
+    void deleteById(long id);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
@@ -1,0 +1,10 @@
+package com.devoops.domain.repository.github;
+
+import com.devoops.domain.entity.github.GithubWebhook;
+
+public interface GithubWebhookDomainRepository {
+
+    GithubWebhook save(GithubWebhook webHook);
+
+    void deleteByRepositoryId(String repositoryId);
+}

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
@@ -6,5 +6,7 @@ public interface GithubWebhookDomainRepository {
 
     GithubWebhook save(GithubWebhook webHook);
 
-    void deleteByRepositoryId(String repositoryId);
+    GithubWebhook findByRepositoryId(long repositoryId);
+
+    void deleteByRepositoryId(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubWebhookDomainRepository.java
@@ -8,5 +8,5 @@ public interface GithubWebhookDomainRepository {
 
     GithubWebhook findByRepositoryId(long repositoryId);
 
-    void deleteByRepositoryId(long repositoryId);
+    void deleteById(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/PullRequestDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/PullRequestDomainRepository.java
@@ -3,6 +3,7 @@ package com.devoops.domain.repository.github;
 import com.devoops.domain.entity.github.PullRequest;
 import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.entity.github.RecordStatus;
+import java.util.List;
 
 public interface PullRequestDomainRepository {
 
@@ -18,5 +19,9 @@ public interface PullRequestDomainRepository {
 
     PullRequest findByQuestionId(long questionId);
 
+    PullRequests findByRepositoryId(long repositoryId);
+
     PullRequest updateStatus(long pullRequestId, RecordStatus status);
+
+    void deleteAll(PullRequests pullRequests);
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/QuestionDomainRepository.java
@@ -1,16 +1,21 @@
 package com.devoops.domain.repository.github;
 
+import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.github.QuestionAnswer;
 import java.util.List;
 
 public interface QuestionDomainRepository {
 
-    Question findById(long questionId);
-
     Question save(Question question);
+
+    void saveAll(List<Question> questions, long pullRequestId);
+
+    Question findById(long questionId);
 
     List<QuestionAnswer> findAllPrQuestions(long pullRequestId);
 
-    void saveAll(List<Question> questions, long pullRequestId);
+    List<Question> findAllByPullRequests(PullRequests repositoryPrs);
+
+    void deleteAll(List<Question> questions);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubWebhookEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubWebhookEntity.java
@@ -20,13 +20,19 @@ public class GithubWebhookEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private long externalId;
+
     private long repositoryId;
 
     public static GithubWebhookEntity from(GithubWebhook githubWebhook) {
-        return new GithubWebhookEntity(githubWebhook.getId(), githubWebhook.getRepositoryId());
+        return new GithubWebhookEntity(
+                githubWebhook.getId(),
+                githubWebhook.getExternalId(),
+                githubWebhook.getRepositoryId()
+        );
     }
 
     public GithubWebhook toDomainEntity() {
-        return new GithubWebhook(this.id, this.repositoryId);
+        return new GithubWebhook(this.id, this.externalId, this.repositoryId);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubWebhookEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubWebhookEntity.java
@@ -1,0 +1,32 @@
+package com.devoops.jpa.entity.github;
+
+import com.devoops.domain.entity.github.GithubWebhook;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GithubWebhookEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private long repositoryId;
+
+    public static GithubWebhookEntity from(GithubWebhook githubWebhook) {
+        return new GithubWebhookEntity(githubWebhook.getId(), githubWebhook.getRepositoryId());
+    }
+
+    public GithubWebhook toDomainEntity() {
+        return new GithubWebhook(this.id, this.repositoryId);
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerDomainRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.domain.entity.github.Answer;
+import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.repository.github.AnswerDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.jpa.entity.github.AnswerEntity;
-import com.devoops.jpa.entity.github.QuestionEntity;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,5 +51,13 @@ public class AnswerDomainRepositoryImpl implements AnswerDomainRepository {
     @Transactional
     public void deleteById(long answerId) {
         answerJpaRepository.deleteById(answerId);
+    }
+
+    @Override
+    public void deleteAllInQuestions(List<Question> questions) {
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        answerJpaRepository.deleteByQuestionIdIn(questionIds);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerJpaRepository.java
@@ -1,6 +1,7 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.AnswerEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +18,6 @@ public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, Long> {
                               )
             """)
     long getAnswerCountByPullRequestId(@Param(value = "pullRequestId") long pullRequestId);
+
+    void deleteByQuestionIdIn(List<Long> questionIds);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingDomainRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.devoops.jpa.repository.github;
 import com.devoops.domain.entity.github.Answer;
 import com.devoops.domain.entity.github.AnswerRanking;
 import com.devoops.domain.entity.github.AnswerRankings;
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
@@ -10,6 +12,7 @@ import com.devoops.jpa.entity.github.AnswerRankingEntity;
 import com.devoops.jpa.entity.github.PullRequestEntity;
 import com.devoops.jpa.entity.github.QuestionEntity;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -67,6 +70,16 @@ public class AnswerRankingDomainRepositoryImpl implements AnswerRankingDomainRep
     @Transactional
     public void deleteById(long id) {
         answerRankingJpaRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAllInPullRequests(PullRequests pullRequests) {
+        List<Long> pullRequestIds = pullRequests.getValues()
+                .stream()
+                .map(PullRequest::getId)
+                .toList();
+        answerRankingJpaRepository.deleteByPullRequestIdIn(pullRequestIds);
     }
 
     private QuestionEntity findQuestionById(long questionId) {

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/AnswerRankingJpaRepository.java
@@ -10,4 +10,6 @@ public interface AnswerRankingJpaRepository extends JpaRepository<AnswerRankingE
     List<AnswerRankingEntity> findAllByUserId(long userId);
 
     Optional<AnswerRankingEntity> findByPullRequestId(long pullRequestId);
+
+    void deleteByPullRequestIdIn(List<Long> pullRequestIds);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
@@ -56,10 +56,18 @@ public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepositor
     }
 
     @Override
+    @Transactional(readOnly = true)
     public GithubRepository findByExternalId(long externalId) {
         return repoJpaRepository.findByGithubRepositoryId(externalId)
                 .orElseThrow(() -> new GssException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND))
                 .toDomainEntity();
 
     }
+
+    @Override
+    @Transactional
+    public void deleteById(long id) {
+        repoJpaRepository.deleteById(id);
+    }
 }
+

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
@@ -33,7 +33,7 @@ public class GithubWebHookDomainRepositoryImpl implements GithubWebhookDomainRep
 
     @Override
     @Transactional
-    public void deleteByRepositoryId(long repositoryId) {
-        webHookRepository.deleteByRepositoryId(repositoryId);
+    public void deleteById(long id) {
+        webHookRepository.deleteById(id);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.devoops.jpa.repository.github;
+
+import com.devoops.domain.entity.github.GithubWebhook;
+import com.devoops.domain.repository.github.GithubWebhookDomainRepository;
+import com.devoops.jpa.entity.github.GithubWebhookEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GithubWebHookDomainRepositoryImpl implements GithubWebhookDomainRepository {
+
+    private final GithubWebHookJpaRepository webHookRepository;
+
+    public GithubWebhook save(GithubWebhook webHook) {
+        GithubWebhookEntity webHookEntity = GithubWebhookEntity.from(webHook);
+        return webHookRepository.save(webHookEntity)
+                .toDomainEntity();
+    }
+
+    public void deleteByRepositoryId(String repositoryId) {
+        webHookRepository.deleteByRepositoryId(repositoryId);
+    }
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookDomainRepositoryImpl.java
@@ -2,9 +2,12 @@ package com.devoops.jpa.repository.github;
 
 import com.devoops.domain.entity.github.GithubWebhook;
 import com.devoops.domain.repository.github.GithubWebhookDomainRepository;
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.jpa.entity.github.GithubWebhookEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -12,13 +15,25 @@ public class GithubWebHookDomainRepositoryImpl implements GithubWebhookDomainRep
 
     private final GithubWebHookJpaRepository webHookRepository;
 
+    @Override
+    @Transactional
     public GithubWebhook save(GithubWebhook webHook) {
         GithubWebhookEntity webHookEntity = GithubWebhookEntity.from(webHook);
         return webHookRepository.save(webHookEntity)
                 .toDomainEntity();
     }
 
-    public void deleteByRepositoryId(String repositoryId) {
+    @Override
+    @Transactional(readOnly = true)
+    public GithubWebhook findByRepositoryId(long repositoryId) {
+         return webHookRepository.findByRepositoryId(repositoryId)
+                .orElseThrow(() -> new GssException(ErrorCode.WEBHOOK_NOT_FOUND))
+                 .toDomainEntity();
+    }
+
+    @Override
+    @Transactional
+    public void deleteByRepositoryId(long repositoryId) {
         webHookRepository.deleteByRepositoryId(repositoryId);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
@@ -6,7 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GithubWebHookJpaRepository extends JpaRepository<GithubWebhookEntity, Long> {
 
-    void deleteByRepositoryId(long repositoryId);
-
     Optional<GithubWebhookEntity> findByRepositoryId(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
@@ -1,0 +1,9 @@
+package com.devoops.jpa.repository.github;
+
+import com.devoops.jpa.entity.github.GithubWebhookEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GithubWebHookJpaRepository extends JpaRepository<GithubWebhookEntity, Long> {
+
+    void deleteByRepositoryId(String repositoryId);
+}

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubWebHookJpaRepository.java
@@ -1,9 +1,12 @@
 package com.devoops.jpa.repository.github;
 
 import com.devoops.jpa.entity.github.GithubWebhookEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GithubWebHookJpaRepository extends JpaRepository<GithubWebhookEntity, Long> {
 
-    void deleteByRepositoryId(String repositoryId);
+    void deleteByRepositoryId(long repositoryId);
+
+    Optional<GithubWebhookEntity> findByRepositoryId(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestDomainRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.jpa.entity.github.GithubRepositoryEntity;
 import com.devoops.jpa.entity.github.PullRequestEntity;
 import com.devoops.jpa.entity.github.QuestionEntity;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -90,5 +91,24 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
         return pullRequestRepository.findById(questionEntity.getPullRequestId())
                 .orElseThrow(() -> new GssException(ErrorCode.PULL_REQUEST_NOT_FOUND))
                 .toDomainEntity();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PullRequests findByRepositoryId(long repositoryId) {
+         return pullRequestRepository.findAllByRepositoryId(repositoryId)
+                 .stream()
+                 .map(PullRequestEntity::toDomainEntity)
+                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));
+    }
+
+    @Override
+    @Transactional
+    public void deleteAll(PullRequests pullRequests) {
+        List<PullRequestEntity> pullRequestEntities = pullRequests.getValues()
+                .stream()
+                .map(PullRequestEntity::from)
+                .toList();
+        pullRequestRepository.deleteAll(pullRequestEntities);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/PullRequestJpaRepository.java
@@ -1,13 +1,11 @@
 package com.devoops.jpa.repository.github;
 
-import com.devoops.domain.entity.github.QuestionAnswer;
 import com.devoops.jpa.entity.github.PullRequestEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface PullRequestJpaRepository extends JpaRepository<PullRequestEntity, Long> {
 
@@ -16,4 +14,6 @@ public interface PullRequestJpaRepository extends JpaRepository<PullRequestEntit
     Page<PullRequestEntity> findByUserId(long userId, Pageable pageable);
 
     Optional<PullRequestEntity> findById(long id);
+
+    List<PullRequestEntity> findAllByRepositoryId(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionDomainRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.devoops.jpa.repository.github;
 
+import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.github.QuestionAnswer;
 import com.devoops.domain.repository.github.QuestionDomainRepository;
@@ -26,6 +28,15 @@ public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
     }
 
     @Override
+    @Transactional
+    public void saveAll(List<Question> question, long pullRequestId) {
+        List<QuestionEntity> questionEntityList = question.stream()
+                .map(QuestionEntity::from)
+                .toList();
+        questionRepository.saveAll(questionEntityList);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public Question findById(long questionId) {
         QuestionEntity questionEntity = questionRepository.findById(questionId)
@@ -40,11 +51,24 @@ public class QuestionDomainRepositoryImpl implements QuestionDomainRepository {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<Question> findAllByPullRequests(PullRequests pullRequests) {
+        List<Long> pullRequestIds = pullRequests.getValues()
+                .stream()
+                .map(PullRequest::getId)
+                .toList();
+        return questionRepository.findAllByPullRequestIdIn(pullRequestIds)
+                .stream()
+                .map(QuestionEntity::toDomainEntity)
+                .toList();
+    }
+
+    @Override
     @Transactional
-    public void saveAll(List<Question> question, long pullRequestId) {
-        List<QuestionEntity> questionEntityList = question.stream()
+    public void deleteAll(List<Question> questions) {
+        List<QuestionEntity> questionEntities = questions.stream()
                 .map(QuestionEntity::from)
                 .toList();
-        questionRepository.saveAll(questionEntityList);
+        questionRepository.deleteAll(questionEntities);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/QuestionJpaRepository.java
@@ -28,4 +28,8 @@ public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Int
               where qe.pullRequestId = :pullRequestId
             """)
     List<QuestionAnswer> findByPullRequestId(@Param("pullRequestId") long pullRequestId);
+
+    List<QuestionEntity> findAllByPullRequestIdIn(List<Long> pullRequestIds);
+
+    void deleteByPullRequestIdIn(List<Long> pullRequestIds);
 }

--- a/gss-domain/src/main/java/com/devoops/service/pullrequest/PullRequestService.java
+++ b/gss-domain/src/main/java/com/devoops/service/pullrequest/PullRequestService.java
@@ -2,6 +2,7 @@ package com.devoops.service.pullrequest;
 
 import com.devoops.command.request.PullRequestCreateCommand;
 import com.devoops.domain.entity.github.PullRequest;
+import com.devoops.domain.entity.github.PullRequests;
 import com.devoops.domain.entity.github.RecordStatus;
 import com.devoops.domain.repository.github.PullRequestDomainRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,10 @@ public class PullRequestService {
 
     public PullRequest getPullRequest(long pullRequestId) {
         return pullRequestRepository.findById(pullRequestId);
+    }
+
+    public PullRequests findByRepositoryId(long repositoryId) {
+        return pullRequestRepository.findByRepositoryId(repositoryId);
     }
 }
 

--- a/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -3,15 +3,20 @@ package com.devoops.service.repository;
 import com.devoops.command.request.RepositoryCreateCommand;
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.domain.entity.github.PullRequests;
+import com.devoops.domain.entity.github.Question;
 import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.AnswerDomainRepository;
+import com.devoops.domain.repository.github.AnswerRankingDomainRepository;
 import com.devoops.domain.repository.github.GithubRepoDomainRepository;
 import com.devoops.domain.repository.github.PullRequestDomainRepository;
+import com.devoops.domain.repository.github.QuestionDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +24,9 @@ public class RepositoryService {
 
     private final GithubRepoDomainRepository repoRepository;
     private final PullRequestDomainRepository pullRequestRepository;
+    private final AnswerRankingDomainRepository answerRankingRepository;
+    private final AnswerDomainRepository answerRepository;
+    private final QuestionDomainRepository questionRepository;
 
     public GithubRepository save(RepositoryCreateCommand command) {
         if(repoRepository.existsByExternalId(command.externalId())) {
@@ -44,5 +52,17 @@ public class RepositoryService {
 
     public List<GithubRepository> getMyRepositories(User user) {
         return repoRepository.findByUserId(user.getId());
+    }
+
+    @Transactional
+    public void delete(User user, long repositoryId) {
+        GithubRepository repo = repoRepository.findByIdAndUserId(repositoryId, user.getId());
+        repoRepository.deleteById(repo.getId());
+        PullRequests repositoryPrs = pullRequestRepository.findByRepositoryId(repo.getId());
+        pullRequestRepository.deleteAll(repositoryPrs);
+        answerRankingRepository.deleteAllInPullRequests(repositoryPrs);
+        List<Question> questions = questionRepository.findAllByPullRequests(repositoryPrs);
+        questionRepository.deleteAll(questions);
+        answerRepository.deleteAllInQuestions(questions);
     }
 }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/WebhookGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/WebhookGenerator.java
@@ -1,0 +1,20 @@
+package com.devoops.generator;
+
+import com.devoops.domain.entity.github.GithubRepository;
+import com.devoops.domain.entity.github.GithubWebhook;
+import com.devoops.domain.entity.user.User;
+import com.devoops.domain.repository.github.GithubWebhookDomainRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebhookGenerator {
+
+    @Autowired
+    private GithubWebhookDomainRepository githubWebhookDomainRepository;
+
+    public GithubWebhook generate(User user, GithubRepository repository) {
+        GithubWebhook webHook = new GithubWebhook(101L, repository.getId());
+        return githubWebhookDomainRepository.save(webHook);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:
https://fresh-liver.atlassian.net/jira/software/projects/GSS/boards/4?selectedIssue=GSS-126

# 🔂 변경 내역

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 레포지토리를 삭제할 수 있는 API 및 화면 기능이 추가되었습니다.
  * 레포지토리 삭제 시 관련된 웹훅, 풀리퀘스트, 질문, 답변, 답변 랭킹 등 모든 연관 데이터가 함께 삭제됩니다.
  * GitHub 웹훅 등록 및 삭제 기능이 추가되어 연동 관리가 강화되었습니다.

* **버그 수정**
  * 없음

* **테스트**
  * 레포지토리 삭제 시 연관 데이터가 올바르게 삭제되는지 확인하는 테스트가 추가되었습니다.
  * GitHub 웹훅 삭제 기능에 대한 테스트가 추가되었습니다.

* **기타**
  * 내부 구조 개선 및 코드 정리가 일부 진행되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->