### PR TITLE
[REFACTOR] 레포지토리 삭제 시, 웹훅만 끊도록 변경

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
@@ -18,12 +18,14 @@ public record MyRepositoriesResponse(
     public record RepositorySummary(
         long id,
         String name,
+        boolean isTracking,
         int pullRequestCount
     ) {
         public static RepositorySummary from(GithubRepository repository) {
             return new RepositorySummary(
                 repository.getId(),
                 repository.getName(),
+                repository.isTracking(),
                 repository.getPrCount()
             );
         }

--- a/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/MyRepositoriesResponse.java
@@ -2,10 +2,13 @@ package com.devoops.dto.response;
 
 import com.devoops.domain.entity.github.GithubRepository;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record MyRepositoriesResponse(
-    List<RepositorySummary> repositories
+        @ArraySchema(schema = @Schema(description = "레포지토리 내역", implementation = RepositorySummary.class))
+        List<RepositorySummary> repositories
 ) {
     public static MyRepositoriesResponse from(List<GithubRepository> repositories) {
         return new MyRepositoriesResponse(
@@ -16,10 +19,17 @@ public record MyRepositoriesResponse(
     }
 
     public record RepositorySummary(
-        long id,
-        String name,
-        boolean isTracking,
-        int pullRequestCount
+            @Schema(description = "레포지토리 아이디", example = "1")
+            long id,
+
+            @Schema(description = "레포지토리 이름", example = "my-repo")
+            String name,
+
+            @Schema(description = "레포지토리 추적 여부", example = "true")
+            boolean isTracking,
+
+            @Schema(description = "레포지토리 풀 리퀘스트 개수", example = "10")
+            int pullRequestCount
     ) {
         public static RepositorySummary from(GithubRepository repository) {
             return new RepositorySummary(

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -63,6 +63,6 @@ public class RepositoryFacadeService {
     @Transactional
     public void deleteRepository(User user, long repositoryId) {
         gitHubService.deleteWebhook(user, repositoryId);
-        repositoryService.delete(user, repositoryId);
+        repositoryService.stopTrackingRepository(user, repositoryId);
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
@@ -178,40 +178,18 @@ class RepositoryServiceTest extends BaseServiceTest {
     }
 
     @Nested
-    class Delete {
+    class StopTracking {
 
         @Test
-        void 레포지토리를_삭제할_수_있다() {
+        void 레포지토리의_트래킹을_끊을_수_있다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
-            Question question1 = questionGenerator.generate(pr1, "질문1");
-            Question question2 = questionGenerator.generate(pr2, "질문2");
-            Answer answer1 = answerGenerator.generate(question1, "answer1");
-            Answer answer2 = answerGenerator.generate(question2, "answer2");
-            AnswerRanking answerRanking1 = answerRankingGenerator.generate(pr1, question1, answer1, user.getId());
-            AnswerRanking answerRanking2 = answerRankingGenerator.generate(pr2, question2, answer2, user.getId());
 
-            repositoryService.delete(user, repo.getId());
+            repositoryService.stopTrackingRepository(user, repo.getId());
 
-            boolean exists = githubRepoDomainRepository.existsByIdAndUserId(repo.getId(), user.getId());
-            PullRequests repositoryPrs = pullRequestDomainRepository.findByRepositoryId(repo.getId());
-            List<QuestionAnswer> pr1Questions = questionDomainRepository.findAllPrQuestions(pr1.getId());
-            List<QuestionAnswer> pr2Questions = questionDomainRepository.findAllPrQuestions(pr2.getId());
-            AnswerRankings userAnswerRankings = answerRankingDomainRepository.findAllByUserId(user.getId());
-            long pr1AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr1.getId());
-            long pr2AnswerCount = answerDomainRepository.getAnswerCountByPullRequestId(pr2.getId());
+            GithubRepository foundRepository = githubRepoDomainRepository.findByIdAndUserId(repo.getId(), user.getId());
 
-            assertAll(
-                    () -> assertThat(exists).isFalse(),
-                    () -> assertThat(repositoryPrs.getValues()).isEmpty(),
-                    () -> assertThat(pr1Questions).isEmpty(),
-                    () -> assertThat(pr2Questions).isEmpty(),
-                    () -> assertThat(userAnswerRankings.getRankings()).isEmpty(),
-                    () -> assertThat(pr1AnswerCount).isZero(),
-                    () -> assertThat(pr2AnswerCount).isZero()
-            );
+            assertThat(foundRepository.isTracking()).isFalse();
         }
     }
 }

--- a/gss-domain/src/main/java/com/devoops/command/request/RepositoryCreateCommand.java
+++ b/gss-domain/src/main/java/com/devoops/command/request/RepositoryCreateCommand.java
@@ -12,6 +12,6 @@ public record RepositoryCreateCommand(
 ) {
 
     public GithubRepository toDomainEntity() {
-        return new GithubRepository(userId, repositoryName, url, ownerName, prCount, externalId);
+        return new GithubRepository(userId, repositoryName, url, ownerName, prCount, externalId, true);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/GithubRepository.java
@@ -14,8 +14,13 @@ public class GithubRepository {
     private final String owner;
     private final int prCount;
     private final long externalId;
+    private final boolean isTracking;
 
-    public GithubRepository(long userId, String name, String url, String owner, int prCount, long externalId) {
-        this(null, userId, name, url, owner, prCount, externalId);
+    public GithubRepository(long userId, String name, String url, String owner, int prCount, long externalId, boolean isTracking) {
+        this(null, userId, name, url, owner, prCount, externalId, isTracking);
+    }
+
+    public GithubRepository stopTracking() {
+        return new GithubRepository(id, userId, name, url, owner, prCount, externalId, false);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/GithubRepoDomainRepository.java
@@ -8,6 +8,8 @@ public interface GithubRepoDomainRepository {
 
     GithubRepository save(GithubRepository githubRepository);
 
+    GithubRepository update(GithubRepository githubRepository);
+
     boolean existsByIdAndUserId(long id, long userId);
 
     GithubRepository findByIdAndUserId(long id, long userId);

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -36,6 +36,7 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     @NotNull
     private String owner;
 
+    @Column(name = "is_tracking")
     private boolean isTracking;
 
     private int pullRequestCount;

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/GithubRepositoryEntity.java
@@ -2,8 +2,12 @@ package com.devoops.jpa.entity.github;
 
 import com.devoops.domain.entity.github.GithubRepository;
 import com.devoops.jpa.entity.BaseTimeEntity;
-import com.devoops.jpa.entity.user.UserEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,6 +36,8 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     @NotNull
     private String owner;
 
+    private boolean isTracking;
+
     private int pullRequestCount;
 
     @Column(unique = true)
@@ -40,26 +46,40 @@ public class GithubRepositoryEntity extends BaseTimeEntity {
     public static GithubRepositoryEntity from(GithubRepository githubRepository) {
 
         return new GithubRepositoryEntity(
-            githubRepository.getId(),
-            githubRepository.getUserId(),
-            githubRepository.getName(),
-            githubRepository.getUrl(),
-            githubRepository.getOwner(),
-            githubRepository.getPrCount(),
-            githubRepository.getExternalId()
+                githubRepository.getId(),
+                githubRepository.getUserId(),
+                githubRepository.getName(),
+                githubRepository.getUrl(),
+                githubRepository.getOwner(),
+                githubRepository.isTracking(),
+                githubRepository.getPrCount(),
+                githubRepository.getExternalId()
         );
+    }
+
+    public GithubRepositoryEntity update(GithubRepository githubRepository) {
+        this.id = githubRepository.getId();
+        this.userId = githubRepository.getUserId();
+        this.name = githubRepository.getName();
+        this.url = githubRepository.getUrl();
+        this.owner = githubRepository.getOwner();
+        this.pullRequestCount = githubRepository.getPrCount();
+        this.githubRepositoryId = githubRepository.getId();
+        this.isTracking = githubRepository.isTracking();
+        return this;
     }
 
     public GithubRepository toDomainEntity() {
         return new GithubRepository(
-            this.id,
-            this.userId,
-            this.name,
-            this.url,
-            this.owner,
-            this.pullRequestCount,
-            this.githubRepositoryId
-        );
+                this.id,
+                this.userId,
+                this.name,
+                this.url,
+                this.owner,
+                this.pullRequestCount,
+                this.githubRepositoryId,
+                this.isTracking
+                );
     }
 
     public void plusPrCount() {

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/GithubRepoDomainRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.devoops.domain.repository.github.GithubRepoDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.jpa.entity.github.GithubRepositoryEntity;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,15 @@ public class GithubRepoDomainRepositoryImpl implements GithubRepoDomainRepositor
         GithubRepositoryEntity repositoryEntity = GithubRepositoryEntity.from(githubRepository);
         GithubRepositoryEntity savedRepositoryEntity = repoJpaRepository.save(repositoryEntity);
         return savedRepositoryEntity.toDomainEntity();
+    }
+
+    @Override
+    @Transactional
+    public GithubRepository update(GithubRepository githubRepository) {
+        GithubRepositoryEntity githubRepositoryEntity = repoJpaRepository.findById(githubRepository.getId())
+                 .orElseThrow(() -> new GssException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND));
+        return githubRepositoryEntity.update(githubRepository)
+                .toDomainEntity();
     }
 
     @Override

--- a/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -55,14 +55,9 @@ public class RepositoryService {
     }
 
     @Transactional
-    public void delete(User user, long repositoryId) {
+    public void stopTrackingRepository(User user, long repositoryId) {
         GithubRepository repo = repoRepository.findByIdAndUserId(repositoryId, user.getId());
-        repoRepository.deleteById(repo.getId());
-        PullRequests repositoryPrs = pullRequestRepository.findByRepositoryId(repo.getId());
-        pullRequestRepository.deleteAll(repositoryPrs);
-        answerRankingRepository.deleteAllInPullRequests(repositoryPrs);
-        List<Question> questions = questionRepository.findAllByPullRequests(repositoryPrs);
-        questionRepository.deleteAll(questions);
-        answerRepository.deleteAllInQuestions(questions);
+        GithubRepository updatedRepository = repo.stopTracking();
+        repoRepository.update(updatedRepository);
     }
 }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/GithubRepoGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/GithubRepoGenerator.java
@@ -21,7 +21,8 @@ public class GithubRepoGenerator {
                 "url",
                 "owner",
                 0,
-                ThreadLocalRandom.current().nextLong()
+                ThreadLocalRandom.current().nextLong(),
+                true
         );
         return githubRepoDomainRepository.save(repository);
     }


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
기존에 레포지토리를 삭제시 -> 레포지토리와 웹훅 + 회고 내역들도 통째로 삭제

=> 변경 후:
레포지토리의 웹훅만 삭제하고 기존 회고내역은 유지하도록 변경

# 🔂 변경 내역

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 레포지토리의 추적(트래킹) 여부를 나타내는 기능이 추가되었습니다. 이제 각 레포지토리의 추적 상태를 확인할 수 있습니다.

* **버그 수정**
  * 레포지토리 삭제 기능이 '추적 중지'로 변경되어, 레포지토리 및 관련 데이터가 완전히 삭제되지 않고 추적만 중단됩니다.

* **문서화**
  * API 응답에 대한 Swagger 문서가 개선되어 각 필드의 설명과 예시가 추가되었습니다.

* **테스트**
  * 레포지토리 삭제 관련 테스트가 '추적 중지' 동작을 검증하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->