### PR TITLE
[FEAT] 유저가 임의로 웹훅 삭제 시, 트래킹을 끊는 로직 작성

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
@@ -106,7 +106,7 @@ public class GitHubService {
                     webhook.getExternalId()
             );
         } catch (GithubNotFoundException githubNotFoundException) {
-            log.error("깃허브 레포에서 웹훅을 찾을 수 없습니다 : {}, repo : {} ", githubNotFoundException, repo);
+            log.error("깃허브 레포에서 웹훅을 찾을 수 없습니다 : {}, repo : {} ", githubNotFoundException, repo.getName());
         }
     }
 }

--- a/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/GitHubService.java
@@ -13,15 +13,17 @@ import com.devoops.dto.request.GithubRepoUrl;
 import com.devoops.dto.response.GithubPrResponse;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.WebHookCreateResponse;
+import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
-import com.devoops.jpa.repository.github.GithubWebHookDomainRepositoryImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GitHubService {
@@ -91,12 +93,20 @@ public class GitHubService {
         GithubToken githubToken = githubTokenDomainRepository.findByUserId(user)
                 .orElseThrow(() -> new GssException(ErrorCode.NO_RESOURCE_FOUND));
         GithubWebhook webhook = githubWebhookDomainRepository.findByRepositoryId(repo.getId());
-        gitHubClient.deleteWebhook(
-                BEARER_PREFIX + githubToken.getToken(),
-                repo.getOwner(),
-                repo.getName(),
-                webhook.getExternalId()
-        );
+        tryDeleteWebhook(githubToken, webhook, repo);
         githubWebhookDomainRepository.deleteById(webhook.getId());
+    }
+
+    private void tryDeleteWebhook(GithubToken githubToken, GithubWebhook webhook, GithubRepository repo) {
+        try {
+            gitHubClient.deleteWebhook(
+                    BEARER_PREFIX + githubToken.getToken(),
+                    repo.getOwner(),
+                    repo.getName(),
+                    webhook.getExternalId()
+            );
+        } catch (GithubNotFoundException githubNotFoundException) {
+            log.error("깃허브 레포에서 웹훅을 찾을 수 없습니다 : {}, repo : {} ", githubNotFoundException, repo);
+        }
     }
 }

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 
@@ -16,6 +17,7 @@ import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
 import com.devoops.dto.response.WebHookCreateResponse;
+import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import org.junit.jupiter.api.Nested;
@@ -76,6 +78,25 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
                     .thenReturn(mockResponse);
             Mockito.when(gitHubClient.createWebhook(any(), any(), any(), any()))
                     .thenReturn(mockWebHookCreateResponse);
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void 웹훅을_찾지_못해도_레포지토리_트래킹을_끊을_수_있다() {
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
+            webhookGenerator.generate(user, repo);
+            Mockito.doThrow(new GithubNotFoundException("mocking error"))
+                    .when(gitHubClient)
+                    .deleteWebhook(anyString(), anyString(), anyString(), anyLong());
+
+            repositoryFacadeService.deleteRepository(user, repo.getId());
+
+            GithubRepository foundRepo = githubRepoDomainRepository.findByIdAndUserId(repo.getId(), user.getId());
+            assertThat(foundRepo.isTracking()).isFalse();
         }
     }
 }

--- a/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
@@ -1,5 +1,6 @@
 package com.devoops.client;
 
+import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class GithubExchangeFilterFunction {
                                     "response", body
                             ));
                             if (response.statusCode().isSameCodeAs(HttpStatusCode.valueOf(404))) {
-                                return Mono.error(new GssException(ErrorCode.MALFORMED_GITHUB_REPOSITORY_URL));
+                                return Mono.error(new GithubNotFoundException("깃허브에서 자원을 찾을 수 없습니다."));
                             }
                             return Mono.error(new GssException(ErrorCode.GITHUB_CLIENT_ERROR));
                         });

--- a/gss-client/gss-github-client/src/main/java/com/devoops/exception/GithubNotFoundException.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/exception/GithubNotFoundException.java
@@ -1,0 +1,7 @@
+package com.devoops.exception;
+
+public class GithubNotFoundException extends RuntimeException {
+    public GithubNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 JIRA 이슈
jira issue url:

유저가 임의로 웹훅을 삭제했다면 GithubNotFoundException이 발생하여 트래킹을 끊는 작업이 불가합니다.
이에 웹훅을 찾지 못하더라도 repo의 상태를 isTracking=false로 바꿀 수 있도록 수정합니다.

# 🔂 변경 내역

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * GitHub 웹훅 삭제 시 웹훅이 존재하지 않아도 오류를 적절히 처리하도록 개선되었습니다.

* **테스트**
  * 웹훅이 존재하지 않아도 레포지토리 트래킹이 정상적으로 중단되는지 확인하는 테스트가 추가되었습니다.

* **신규 기능**
  * GitHub 리소스를 찾을 수 없을 때를 위한 전용 예외가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->