### PR TITLE
refactor: 레포지토리 저장 로직 변경

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -17,7 +17,6 @@ import com.devoops.service.GitHubService;
 import com.devoops.service.github.WebHookService;
 import com.devoops.service.repository.RepositoryService;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -36,8 +35,11 @@ public class RepositoryFacadeService {
     public GithubRepository save(RepositorySaveRequest request, User user) {
         try {
             GithubRepoUrl repoUrl = new GithubRepoUrl(request.url());
-            GithubRepository savedRepository = saveRepository(repoUrl, user);
-            webHookService.registerWebhook(user, savedRepository.getId());
+            GithubRepoInfoResponse repositoryInfo = gitHubService.getRepositoryInfo(repoUrl, user.getGithubToken());
+            GithubRepository savedRepository = repositoryService.findByUserAndExternalId(user, repositoryInfo.id())
+                            .map(alreadyRegisteredRepo -> reTrackingOrThrowException(user, alreadyRegisteredRepo))
+                            .orElseGet(() -> registerNewRepo(repositoryInfo, repoUrl, user));
+
             eventPublisher.publishEvent(new AnalyzeMyPrEvent(repoUrl, user, this));
             return savedRepository;
         } catch (GithubNotFoundException githubNotFoundException) {
@@ -45,15 +47,11 @@ public class RepositoryFacadeService {
         }
     }
 
-    private GithubRepository saveRepository(GithubRepoUrl url, User user) {
-        GithubRepoInfoResponse repositoryInfo = gitHubService.getRepositoryInfo(url, user.getGithubToken());
-        long externalId = repositoryInfo.id();
-        Optional<GithubRepository> alreadyRegisteredRepo = repositoryService.findByUserAndExternalId(user, externalId);
-
-        if(alreadyRegisteredRepo.isPresent()) {
-            return reTrackingOrThrowException(user, alreadyRegisteredRepo.get());
-        }
-
+    private GithubRepository registerNewRepo(
+            GithubRepoInfoResponse repositoryInfo,
+            GithubRepoUrl url,
+            User user
+    ) {
         RepositoryCreateCommand createCommand = new RepositoryCreateCommand(
                 user.getId(),
                 repositoryInfo.name(),
@@ -62,7 +60,9 @@ public class RepositoryFacadeService {
                 INITIAL_PULL_REQUEST_COUNT,
                 repositoryInfo.id()
         );
-        return repositoryService.save(createCommand);
+        GithubRepository savedRepository = repositoryService.save(createCommand);
+        webHookService.registerWebhook(user, savedRepository.getId());
+        return savedRepository;
     }
 
     private GithubRepository reTrackingOrThrowException(User user, GithubRepository registeredRepo) {

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package com.devoops.service.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +70,7 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         }
 
         @Test
-        void 레포지토리를_중복_저장할_수_없다() {
+        void 동일_유저가_레포지토리를_중복_저장할_수_없다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
             mockingGithubClient();
@@ -82,23 +83,32 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         }
 
         @Test
+        void 다른_유저가_레포지토리를_중복_저장할_수_있다() {
+            User user1 = userGenerator.generate("김건우1");
+            User user2 = userGenerator.generate("김건우2");
+            RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
+            mockingGithubClient();
+
+            assertThatCode(() -> {
+                repositoryFacadeService.save(request, user1);
+                repositoryFacadeService.save(request, user2);
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
         void 레포지토리를_재연결_할_수_있다() {
             User user = userGenerator.generate("김건우");
             GithubRepository unTrackingRepo = repoGenerator.generate(user, "연결 끊긴 레포지토리", 123L, false);
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
             mockingGithubClient();
 
-            GithubRepository reTrackingRepository = repositoryFacadeService.save(request, user);
+            repositoryFacadeService.save(request, user);
 
             GithubRepository actual = githubRepoDomainRepository.findByIdAndUserId(
                     unTrackingRepo.getId(),
                     user.getId()
             );
-
-            assertAll(
-                    () -> Mockito.verify(gitHubClient, times(1)).createWebhook(any(), any(), any(), any()),
-                    () -> assertThat(actual.isTracking()).isTrue()
-            );
+            assertThat(actual.isTracking()).isTrue();
         }
 
         private void mockingGithubClient() {

--- a/gss-domain/src/main/java/com/devoops/domain/entity/analysis/ClaudeAiModel.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/analysis/ClaudeAiModel.java
@@ -15,6 +15,7 @@ public enum ClaudeAiModel implements AiModel {
     private final double inputTokenCharge; //달러
     private final double outputTokenCharge; //달러
 
+    @Override
     public double getCharge(int promptToken, int completionTokens) {
         double inputCharge = CurrencyUtil.usdToKrw(inputTokenCharge * promptToken);
         double outputCharge = CurrencyUtil.usdToKrw(outputTokenCharge * completionTokens);

--- a/gss-domain/src/main/java/com/devoops/domain/entity/analysis/OpenAiModel.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/analysis/OpenAiModel.java
@@ -36,6 +36,7 @@ public enum OpenAiModel implements AiModel {
         return currentUsage >= min && currentUsage <= max;
     }
 
+    @Override
     public double getCharge(int promptToken, int completionTokens) {
         double inputCharge = CurrencyUtil.usdToKrw(inputTokenCharge * promptToken);
         double outputCharge = CurrencyUtil.usdToKrw(outputTokenCharge * completionTokens);


### PR DESCRIPTION
# 🚩 연관 이슈

# 🔂 변경 내역


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 서로 다른 사용자가 동일한 저장소를 각각 등록할 수 있도록 개선했습니다.
  - 이미 추적 중인 저장소를 다시 연결할 때 불필요한 웹훅 재등록을 방지했습니다.
  - 재추적 시 부작용 없이 정상적으로 추적이 재개되도록 동작을 보완했습니다.

- 테스트
  - 사용자 간 저장소 중복 등록 허용 시나리오를 추가하고, 동일 사용자 중복 등록 금지 케이스를 명확화했습니다.
  - 재연결 관련 검증을 현재 동작에 맞게 조정했습니다.

- 기타
  - 일부 모델 구현에 주석 보강으로 코드 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->