### PR TITLE
[REFACOTR] AI_비용_저장_동시성_이슈 해결

### DIFF
--- a/gss-api-app/src/test/java/com/devoops/repository/analysis/AiChargeRepositoryTest.java
+++ b/gss-api-app/src/test/java/com/devoops/repository/analysis/AiChargeRepositoryTest.java
@@ -1,10 +1,13 @@
 package com.devoops.repository.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.domain.entity.analysis.AiCharge;
 import com.devoops.domain.repository.analysis.AiChargeRepository;
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,13 +33,14 @@ class AiChargeRepositoryTest extends BaseServiceTest {
         }
 
         @Test
-        void 가져올_요금이_없다면_초기화한다() {
+        void 가져올_요금이_없다면_에러가_발생한다() {
             LocalDate localDate = LocalDate.now();
 
-            AiCharge actual = chargeRepository.getByYearAndMonth(localDate.getYear(), localDate.getMonthValue());
-
-            assertThat(actual.getCharge().doubleValue()).isEqualTo(0.0);
+            assertThatThrownBy(() -> chargeRepository.getByYearAndMonth(localDate.getYear(), localDate.getMonthValue()))
+                    .isInstanceOf(GssException.class)
+                    .hasMessage(ErrorCode.AI_CHARGE_NOT_FOUND.getMessage());
         }
+
     }
 
     @Nested

--- a/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
+++ b/gss-common/src/main/java/com/devoops/exception/errorcode/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
     REDIS_SUBSCRIBE_ERROR(500, "레디스 이벤트 수신 과정에서 문제가 생겼습니다"),
     GITHUB_CLIENT_ERROR(500, "깃허브 클라이언트 소통과정에 문제가 발생했습니다"),
     AI_RESPONSE_PARSING_ERROR(500, "AI로부터 온 질문 생성을 파싱하는 과정에 오류가 발생했습니다"),
-    AI_CREATE_QUESTION_ERROR(500, "AI 질문 생성과정에 오류가 발생했습니다")
+    AI_CREATE_QUESTION_ERROR(500, "AI 질문 생성과정에 오류가 발생했습니다"),
+    AI_CHARGE_NOT_FOUND(500, "당월 AI 비용을 찾을 없습니다.")
     ;
 
     private final int statusCode;

--- a/gss-domain/src/main/java/com/devoops/domain/repository/analysis/AiChargeRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/analysis/AiChargeRepository.java
@@ -7,4 +7,6 @@ public interface AiChargeRepository {
     AiCharge getByYearAndMonth(int year, int month);
 
     void addCharge(int year, int month, double charge);
+
+    AiCharge save(AiCharge charge);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/analysis/AiChargeRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/analysis/AiChargeRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.devoops.jpa.repository.analysis;
 
 import com.devoops.domain.entity.analysis.AiCharge;
 import com.devoops.domain.repository.analysis.AiChargeRepository;
+import com.devoops.exception.custom.GssException;
+import com.devoops.exception.errorcode.ErrorCode;
 import com.devoops.jpa.entity.analysis.AiChargeEntity;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +19,20 @@ public class AiChargeRepositoryImpl implements AiChargeRepository {
     @Override
     public AiCharge getByYearAndMonth(int year, int month) {
         return chargeJpaRepository.findByYearAndMonth(year, month)
-                .orElseGet(() -> {
-                    AiCharge initializeCharge = new AiCharge(year, month, BigDecimal.ZERO);
-                    return chargeJpaRepository.save(AiChargeEntity.from(initializeCharge));
-                }).toDomainEntity();
+                .orElseThrow(() -> new GssException(ErrorCode.AI_CHARGE_NOT_FOUND))
+                .toDomainEntity();
     }
 
     @Override
     @Transactional
     public void addCharge(int year, int month, double charge) {
         chargeJpaRepository.updateChargeById(year, month, charge);
+    }
+
+    @Override
+    @Transactional
+    public AiCharge save(AiCharge charge) {
+        return chargeJpaRepository.save(AiChargeEntity.from(charge))
+                .toDomainEntity();
     }
 }

--- a/gss-domain/src/main/java/com/devoops/service/pranalysis/AiChargeService.java
+++ b/gss-domain/src/main/java/com/devoops/service/pranalysis/AiChargeService.java
@@ -2,7 +2,9 @@ package com.devoops.service.pranalysis;
 
 import com.devoops.domain.entity.analysis.AiCharge;
 import com.devoops.domain.repository.analysis.AiChargeRepository;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,17 +13,24 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AiChargeService {
 
+    private static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     private final AiChargeRepository chargeRepository;
 
+    public AiCharge initializeNextMonth() {
+        LocalDate now = LocalDate.now(SEOUL_ZONE_ID);
+        YearMonth nextMonth = YearMonth.from(now).plusMonths(1);
+        AiCharge aiCharge = new AiCharge(nextMonth.getYear(), nextMonth.getMonthValue(), BigDecimal.ZERO);
+        return chargeRepository.save(aiCharge);
+    }
+
     public AiCharge getMonthlyCharge() {
-        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(seoulZoneId);
+        LocalDate today = LocalDate.now(SEOUL_ZONE_ID);
         return chargeRepository.getByYearAndMonth(today.getYear(), today.getMonthValue());
     }
 
     public void addCharge(double consumedCharge) {
-        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(seoulZoneId);
+        LocalDate today = LocalDate.now(SEOUL_ZONE_ID);
         chargeRepository.addCharge(today.getYear(), today.getMonthValue(), consumedCharge);
     }
 }

--- a/gss-domain/src/main/java/com/devoops/service/pranalysis/AiChargeService.java
+++ b/gss-domain/src/main/java/com/devoops/service/pranalysis/AiChargeService.java
@@ -1,0 +1,27 @@
+package com.devoops.service.pranalysis;
+
+import com.devoops.domain.entity.analysis.AiCharge;
+import com.devoops.domain.repository.analysis.AiChargeRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiChargeService {
+
+    private final AiChargeRepository chargeRepository;
+
+    public AiCharge getMonthlyCharge() {
+        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
+        LocalDate today = LocalDate.now(seoulZoneId);
+        return chargeRepository.getByYearAndMonth(today.getYear(), today.getMonthValue());
+    }
+
+    public void addCharge(double consumedCharge) {
+        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
+        LocalDate today = LocalDate.now(seoulZoneId);
+        chargeRepository.addCharge(today.getYear(), today.getMonthValue(), consumedCharge);
+    }
+}

--- a/gss-mcp-app/src/main/java/com/devoops/config/SchedulingConfig.java
+++ b/gss-mcp-app/src/main/java/com/devoops/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.devoops.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/gss-mcp-app/src/main/java/com/devoops/event/QuestionEventListener.java
+++ b/gss-mcp-app/src/main/java/com/devoops/event/QuestionEventListener.java
@@ -7,7 +7,7 @@ import com.devoops.domain.entity.github.token.GithubToken;
 import com.devoops.dto.AppWebhookEventRequest;
 import com.devoops.dto.request.AdaptedAnalyzePrResponse;
 import com.devoops.dto.response.PrAnalysis;
-import com.devoops.service.pranalysis.PrAnalysisService;
+import com.devoops.service.pranalysis.PrAnalysisFacadeService;
 import com.devoops.service.pullrequest.PullRequestService;
 import com.devoops.service.question.QuestionService;
 import java.util.List;
@@ -22,7 +22,7 @@ public class QuestionEventListener {
 
     private final PullRequestService pullRequestService;
     private final QuestionService questionService;
-    private final PrAnalysisService prAnalysisService;
+    private final PrAnalysisFacadeService prAnalysisFacadeService;
 
     @Async
     @EventListener(QuestionCreateEvent.class)
@@ -31,7 +31,7 @@ public class QuestionEventListener {
         GithubToken githubToken = questionCreateEvent.getToken();
         PullRequest readyPullRequest = questionCreateEvent.getInitializedPullRequest();
 
-        AdaptedAnalyzePrResponse adaptedAnalyzePrResponse = prAnalysisService.analyzePullRequest(request, githubToken);
+        AdaptedAnalyzePrResponse adaptedAnalyzePrResponse = prAnalysisFacadeService.analyzePullRequest(request, githubToken);
 
         PullRequest updatedPullRequest = pullRequestService.updateAnalyzeResult(
                 readyPullRequest.getId(),

--- a/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/AiChargeScheduler.java
+++ b/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/AiChargeScheduler.java
@@ -10,7 +10,7 @@ class AiChargeScheduler {
 
     private final AiChargeService aiChargeService;
 
-    @Scheduled(cron = "0 55 23 L * ?")
+    @Scheduled(cron = "0 55 23 L * ?", zone = "Asia/Seoul")
     public void createNextMonthCharge() {
         aiChargeService.initializeNextMonth();
     }

--- a/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/AiChargeScheduler.java
+++ b/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/AiChargeScheduler.java
@@ -1,0 +1,17 @@
+package com.devoops.service.pranalysis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class AiChargeScheduler {
+
+    private final AiChargeService aiChargeService;
+
+    @Scheduled(cron = "0 55 23 L * ?")
+    public void createNextMonthCharge() {
+        aiChargeService.initializeNextMonth();
+    }
+}

--- a/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/PrAnalysisFacadeService.java
+++ b/gss-mcp-app/src/main/java/com/devoops/service/pranalysis/PrAnalysisFacadeService.java
@@ -8,24 +8,20 @@ import com.devoops.domain.entity.github.token.GithubToken;
 import com.devoops.domain.repository.analysis.AiChargeRepository;
 import com.devoops.dto.AppWebhookEventRequest;
 import com.devoops.dto.request.AdaptedAnalyzePrResponse;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PrAnalysisService {
+public class PrAnalysisFacadeService {
 
     private final GithubAdaptor githubAdaptor;
     private final PrAnalysisAdapter prAnalysisAdapter;
-    private final AiChargeRepository chargeRepository;
+    private final AiChargeService aiChargeService;
 
     public AdaptedAnalyzePrResponse analyzePullRequest(AppWebhookEventRequest request, GithubToken githubToken) {
         String diff = githubAdaptor.getCodeChangeHistory(request.diffUrl(), githubToken.getToken());
-        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(seoulZoneId);
-        AiCharge aiCharge = chargeRepository.getByYearAndMonth(today.getYear(), today.getMonthValue());
+        AiCharge aiCharge = aiChargeService.getMonthlyCharge();
         OpenAiModel aiModel = OpenAiModel.getModelByUsage(aiCharge.getCharge());
 
         AdaptedAnalyzePrResponse result = prAnalysisAdapter.analyze(
@@ -36,7 +32,7 @@ public class PrAnalysisService {
         );
 
         double consumedCharge = aiModel.getCharge(result.promptTokens(), result.completionTokens());
-        chargeRepository.addCharge(today.getYear(), today.getMonthValue(), consumedCharge);
+        aiChargeService.addCharge(consumedCharge);
         return result;
     }
 }

--- a/gss-mcp-app/src/test/java/com/devoops/service/pranalysis/AiChargeSchedulerTest.java
+++ b/gss-mcp-app/src/test/java/com/devoops/service/pranalysis/AiChargeSchedulerTest.java
@@ -1,0 +1,47 @@
+package com.devoops.service.pranalysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.devoops.BaseMcpTest;
+import com.devoops.domain.entity.analysis.AiCharge;
+import com.devoops.domain.repository.analysis.AiChargeRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AiChargeSchedulerTest extends BaseMcpTest {
+
+    @Autowired
+    private AiChargeScheduler aiChargeScheduler;
+
+    @Autowired
+    private AiChargeRepository aiChargeRepository;
+
+    @Nested
+    class CreateNextMonthCharge {
+
+        @Test
+        void 다음달_비용을_초기화한다() {
+            ZoneId zoneId = ZoneId.of("Asia/Seoul");
+            YearMonth yearMonth = YearMonth.from(LocalDate.now(zoneId));
+            YearMonth nextMonth = yearMonth.plusMonths(1);
+
+            aiChargeScheduler.createNextMonthCharge();
+
+            AiCharge nextMonthAiCharge = aiChargeRepository.getByYearAndMonth(
+                    nextMonth.getYear(),
+                    nextMonth.getMonthValue()
+            );
+            assertAll(
+                    () -> assertThat(nextMonthAiCharge.getYear()).isEqualTo(nextMonth.getYear()),
+                    () -> assertThat(nextMonthAiCharge.getMonth()).isEqualTo(nextMonth.getMonthValue()),
+                    () -> assertThat(nextMonthAiCharge.getCharge().doubleValue()).isEqualTo(0.0)
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
# 🚩 연관 이슈
close #84 

# 🔂 변경 내역
- ai 비용이 exists -> save 패턴을 사용하다보니 동시성 이슈로 중복 저장문제가 발생
- 다음달 ai 비용을 매달 말일에 미리 적용하도록 스케쥴링 로직 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 월말(Asia/Seoul) 23:55에 익월 AI 비용을 자동 생성하는 스케줄러 추가
  - 애플리케이션 전역 스케줄링 활성화
  - 월간 AI 비용 조회·저장·가산을 담당하는 서비스 도입
- 리팩터
  - PR 분석의 비용 처리 로직을 리포지토리 직접 접근에서 서비스 기반으로 전환
  - 이벤트 리스너의 의존성을 퍼사드 서비스로 교체
- 동작 변경
  - 해당 월 비용 미존재 시 0 초기화 대신 예외 발생으로 변경 및 관련 오류 코드 추가
- 테스트
  - 월말 스케줄러 동작 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->