### PR TITLE
[FEAT] 질문이 생성된 PR만 반환되도록 수정

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestReadResponse.java
+++ b/gss-api-app/src/main/java/com/devoops/dto/response/PullRequestReadResponse.java
@@ -1,5 +1,6 @@
 package com.devoops.dto.response;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.QuestionAnswer;
 import com.devoops.domain.entity.github.pr.RecordStatus;
@@ -21,6 +22,10 @@ public record PullRequestReadResponse(
         @NotNull
         @Schema(description = "회고 라밸", example = "feat")
         String tag,
+
+        @NotNull
+        @Schema(description = "질문 생성 상태", example = "PROCESSING")
+        ProcessingStatus processingStatus,
 
         @NotNull
         @Schema(description = "기록 상태", example = "PROGRESS")
@@ -56,6 +61,7 @@ public record PullRequestReadResponse(
                 pullRequest.getId(),
                 pullRequest.getTitle(),
                 pullRequest.getTag(),
+                pullRequest.getProcessingStatus(),
                 pullRequest.getRecordStatus(),
                 pullRequest.getPullRequestUrl(),
                 pullRequest.getMergedAt(),

--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -73,11 +73,11 @@ public class RepositoryFacadeService {
     }
 
     public PullRequests findAllPullRequestsByRepository(User user, long repositoryId, int size, int page) {
-        return repositoryService.getPullRequestsByRepository(user, repositoryId, size, page);
+        return repositoryService.getProcessedPullRequestsByRepository(user, repositoryId, size, page);
     }
 
     public PullRequests findAllPullRequests(User user, int size, int page) {
-        return repositoryService.getPullRequests(user, size, page);
+        return repositoryService.getProcessedPullRequests(user, size, page);
     }
 
     public List<GithubRepository> findMyRepositories(User user) {

--- a/gss-api-app/src/test/java/com/devoops/controller/question/QuestionControllerTest.java
+++ b/gss-api-app/src/test/java/com/devoops/controller/question/QuestionControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseControllerTest;
 import com.devoops.domain.entity.github.answer.Answer;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.question.Question;
@@ -32,7 +33,7 @@ class QuestionControllerTest extends BaseControllerTest {
         void 다수_회고를_업데이트한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pr1, "질문1");
             Question question2 = questionGenerator.generate(pr1, "질문2");
             Answer answer1 = answerGenerator.generate(question1, "answer1");

--- a/gss-api-app/src/test/java/com/devoops/controller/repository/RepositoryControllerTest.java
+++ b/gss-api-app/src/test/java/com/devoops/controller/repository/RepositoryControllerTest.java
@@ -1,6 +1,7 @@
 package com.devoops.controller.repository;
 
 import com.devoops.BaseControllerTest;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
@@ -27,9 +28,9 @@ class RepositoryControllerTest extends BaseControllerTest {
             AccessToken accessToken = tokenManager.createAccessToken(user.getId());
             GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
 
-            PullRequest pr1 = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo, now.minusMinutes(5L));
-            PullRequest pr2 = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo, now.minusMinutes(3L));
-            PullRequest pr3 = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo, now.minusMinutes(1L));
+            PullRequest pr1 = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,  ProcessingStatus.DONE, repo, now.minusMinutes(5L));
+            PullRequest pr2 = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,  ProcessingStatus.DONE, repo, now.minusMinutes(3L));
+            PullRequest pr3 = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,  ProcessingStatus.DONE, repo, now.minusMinutes(1L));
 
             RestAssured.given()
                     .contentType(ContentType.JSON)
@@ -49,7 +50,7 @@ class RepositoryControllerTest extends BaseControllerTest {
             AccessToken accessToken = tokenManager.createAccessToken(seonwoo.getId());
             GithubRepository repo = repoGenerator.generate(beomgeun, "범근형의 레포지토리");
 
-            PullRequest pr1 = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo, now.minusMinutes(5L));
+            PullRequest pr1 = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,  ProcessingStatus.DONE, repo, now.minusMinutes(5L));
 
             RestAssured.given()
                     .contentType(ContentType.JSON)

--- a/gss-api-app/src/test/java/com/devoops/service/answerranking/AnswerRankingServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/answerranking/AnswerRankingServiceTest.java
@@ -7,6 +7,7 @@ import com.devoops.BaseServiceTest;
 import com.devoops.domain.entity.github.answer.Answer;
 import com.devoops.domain.entity.github.answer.AnswerRanking;
 import com.devoops.domain.entity.github.answer.AnswerRankings;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.question.Question;
@@ -35,8 +36,8 @@ class AnswerRankingServiceTest extends BaseServiceTest {
         void PR_랭킹을_저장한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
-                    LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE,
+                    repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             Answer answer = answerGenerator.generate(question1, "answer1");
 
@@ -50,8 +51,8 @@ class AnswerRankingServiceTest extends BaseServiceTest {
         void 유저의_PR_랭킹을_모두_가져온다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pr1, "질문1");
             Question question2 = questionGenerator.generate(pr2, "질문2");
             Answer answer1 = answerGenerator.generate(question1, "answer1");
@@ -72,7 +73,7 @@ class AnswerRankingServiceTest extends BaseServiceTest {
         void 랭킹_PR에_존재하는_질문의_경우_랭킹내역을_업데이트한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pr1, "질문1");
             Question question2 = questionGenerator.generate(pr1, "질문2");
             Answer answer1 = answerGenerator.generate(question1, "answer1");
@@ -93,10 +94,10 @@ class AnswerRankingServiceTest extends BaseServiceTest {
         void 랭킹_PR이_꽉_찼을_경우_가장_오래된_pr을_삭제하고_새로운_pr을_갱신한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr3 = pullRequestGenerator.generate("PR3", RecordStatus.PENDING, repo, LocalDateTime.now());
-            PullRequest pr4 = pullRequestGenerator.generate("PR4", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
+            PullRequest pr2 = pullRequestGenerator.generate("PR2", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
+            PullRequest pr3 = pullRequestGenerator.generate("PR3", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
+            PullRequest pr4 = pullRequestGenerator.generate("PR4", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pr1, "질문1");
             Question question2 = questionGenerator.generate(pr2, "질문2");
             Question question3 = questionGenerator.generate(pr3, "질문3");

--- a/gss-api-app/src/test/java/com/devoops/service/facade/PullRequestFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/PullRequestFacadeServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.domain.entity.github.answer.Answer;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.question.Question;
@@ -28,7 +29,7 @@ class PullRequestFacadeServiceTest extends BaseServiceTest {
         void 풀_리퀘스트_정보를_읽는다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             Question question2 = questionGenerator.generate(pullRequest, "질문2");
             Answer answer1 = answerGenerator.generate(question1, "answerContent");

--- a/gss-api-app/src/test/java/com/devoops/service/facade/PullRequestFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/PullRequestFacadeServiceTest.java
@@ -38,6 +38,7 @@ class PullRequestFacadeServiceTest extends BaseServiceTest {
 
             assertAll(
                     () -> assertThat(response.id()).isEqualTo(pullRequest.getId()),
+                    () -> assertThat(response.processingStatus()).isEqualTo(ProcessingStatus.DONE),
                     () -> assertThat(response.questions()).hasSize(2),
                     () -> assertThat(response.questions().get(0).createdAt()).isNotNull(),
                     () -> assertThat(response.questions().get(1).createdAt()).isNull()

--- a/gss-api-app/src/test/java/com/devoops/service/facade/QuestionFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/QuestionFacadeServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.domain.entity.github.answer.Answer;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.question.Question;
@@ -34,8 +35,12 @@ class QuestionFacadeServiceTest extends BaseServiceTest {
         void 최소_하나의_회고가_생성되면_PR상태가_progress로_변경된다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
-                    LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR",
+                    RecordStatus.PENDING,
+                    ProcessingStatus.DONE,
+                    repo,
+                    LocalDateTime.now()
+            );
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
 
             questionFacadeService.initializeAnswer(question1.getId(), user);
@@ -48,7 +53,9 @@ class QuestionFacadeServiceTest extends BaseServiceTest {
         void 회고를_삭제할_때_PR의_회고가_남아있다면_PR은_PROGRESS를_유지한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS, repo,
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS,
+                    ProcessingStatus.DONE,
+                    repo,
                     LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             Question question2 = questionGenerator.generate(pullRequest, "질문2");
@@ -65,7 +72,9 @@ class QuestionFacadeServiceTest extends BaseServiceTest {
         void 마지막_회고를_삭제하면_PR은_PENDING으로_변경된다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS, repo,
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PROGRESS,
+                    ProcessingStatus.DONE,
+                    repo,
                     LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             Answer answer1 = answerGenerator.generate(question1, "대답1");
@@ -84,7 +93,7 @@ class QuestionFacadeServiceTest extends BaseServiceTest {
         void 다수_회고를_업데이트한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pr1 = pullRequestGenerator.generate("PR1", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pr1, "질문1");
             Question question2 = questionGenerator.generate(pr1, "질문2");
             Answer answer1 = answerGenerator.generate(question1, "answer1");

--- a/gss-api-app/src/test/java/com/devoops/service/pullrequests/PullRequestServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/pullrequests/PullRequestServiceTest.java
@@ -3,6 +3,7 @@ package com.devoops.service.pullrequests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.devoops.BaseServiceTest;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
@@ -25,8 +26,13 @@ class PullRequestServiceTest extends BaseServiceTest {
         void 풀_리퀘스트_회고_상태를_완료로_변경한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo,
-                    LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate(
+                    "최초 PR",
+                    RecordStatus.PENDING,
+                    ProcessingStatus.DONE,
+                    repo,
+                    LocalDateTime.now()
+            );
 
             PullRequest updatedPullRequest = pullRequestService.updateStatus(pullRequest.getId(), RecordStatus.DONE);
 

--- a/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/question/QuestionServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.devoops.BaseServiceTest;
 import com.devoops.command.request.AnswerUpdateCommand;
 import com.devoops.domain.entity.github.answer.Answer;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.question.Question;
@@ -34,7 +35,7 @@ class QuestionServiceTest extends BaseServiceTest {
         void 질문에_대한_최초_응답을_저장한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question = questionGenerator.generate(pullRequest, "질문 : 이거 왜 이렇게 했어요?");
 
             Answer answer = questionService.initializeAnswer(question.getId(), user);
@@ -49,7 +50,7 @@ class QuestionServiceTest extends BaseServiceTest {
         void 질문에_대한_응답을_업데이트한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question = questionGenerator.generate(pullRequest, "질문 : 이거 왜 이렇게 했어요?");
             Answer answer = answerGenerator.generate(question, "before");
 
@@ -65,7 +66,7 @@ class QuestionServiceTest extends BaseServiceTest {
         void 질문에_대한_다수_응답을_업데이트한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             Question question2 = questionGenerator.generate(pullRequest, "질문1");
             Question question3 = questionGenerator.generate(pullRequest, "질문1");
@@ -96,7 +97,7 @@ class QuestionServiceTest extends BaseServiceTest {
         void 풀리퀘스트의_질문과_대답을_모두_조회한다() {
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "건우의 레포");
-            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, repo, LocalDateTime.now());
+            PullRequest pullRequest = pullRequestGenerator.generate("최초 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, LocalDateTime.now());
             Question question1 = questionGenerator.generate(pullRequest, "질문1");
             questionGenerator.generate(pullRequest, "질문1");
             Answer answer1 = answerGenerator.generate(question1, "answerContent");

--- a/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
@@ -66,7 +66,7 @@ class RepositoryServiceTest extends BaseServiceTest {
             PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
                     ProcessingStatus.DONE, repo, now.minusMinutes(1L));
 
-            List<Long> pullRequestsId = repositoryService.getPullRequestsByRepository(user, repo.getId(), 6, 0)
+            List<Long> pullRequestsId = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 6, 0)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
@@ -74,6 +74,28 @@ class RepositoryServiceTest extends BaseServiceTest {
 
             assertThat(pullRequestsId)
                     .containsExactly(oneMinutesAgoPR.getId(), threeMinutesAgoPR.getId(), fiveMinutesAgoPR.getId());
+        }
+
+        @Test
+        void 질문_생성이_완료된_풀_리퀘스트만_가져온다() {
+            LocalDateTime now = LocalDateTime.now();
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(5L));
+            pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.PROCESSING, repo, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(1L));
+
+            List<Long> pullRequestsId = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 6, 0)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            assertThat(pullRequestsId)
+                    .containsExactly(oneMinutesAgoPR.getId(), fiveMinutesAgoPR.getId());
         }
 
         @Test
@@ -88,13 +110,13 @@ class RepositoryServiceTest extends BaseServiceTest {
             PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
                     ProcessingStatus.DONE, repo, now.minusMinutes(1L));
 
-            List<Long> pageOneIds = repositoryService.getPullRequestsByRepository(user, repo.getId(), 2, 0)
+            List<Long> pageOneIds = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 2, 0)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
                     .toList();
 
-            List<Long> pageTwoIds = repositoryService.getPullRequestsByRepository(user, repo.getId(), 2, 1)
+            List<Long> pageTwoIds = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 2, 1)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
@@ -107,6 +129,36 @@ class RepositoryServiceTest extends BaseServiceTest {
         }
 
         @Test
+        void 질문_생성이_완료된_레포지토리_풀_리퀘스트_목록에_페이지네이션을_적용한다() {
+            LocalDateTime now = LocalDateTime.now();
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.PROCESSING, repo, now.minusMinutes(1L));
+
+            List<Long> pageOneIds = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 1, 0)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            List<Long> pageTwoIds = repositoryService.getProcessedPullRequestsByRepository(user, repo.getId(), 1, 1)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            assertAll(
+                    () -> assertThat(pageOneIds).containsOnly(threeMinutesAgoPR.getId()),
+                    () -> assertThat(pageTwoIds).containsOnly(fiveMinutesAgoPR.getId())
+            );
+        }
+
+        @Test
         void 주인이_아니라면_레포지토리_풀_리퀘스트_목록에_접근할_수_없다() {
             LocalDateTime now = LocalDateTime.now();
             User user = userGenerator.generate("김건우");
@@ -114,7 +166,7 @@ class RepositoryServiceTest extends BaseServiceTest {
             GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
             pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, now);
 
-            assertThatThrownBy(() -> repositoryService.getPullRequestsByRepository(seonwoo, repo.getId(), 6, 0))
+            assertThatThrownBy(() -> repositoryService.getProcessedPullRequestsByRepository(seonwoo, repo.getId(), 6, 0))
                     .isInstanceOf(GssException.class)
                     .hasMessage(ErrorCode.REPOSITORY_NOT_FOUND.getMessage());
         }
@@ -137,7 +189,7 @@ class RepositoryServiceTest extends BaseServiceTest {
                     ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
             PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo2, now);
 
-            List<Long> pullRequestsId = repositoryService.getPullRequests(user, 4, 0)
+            List<Long> pullRequestsId = repositoryService.getProcessedPullRequests(user, 4, 0)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
@@ -146,6 +198,30 @@ class RepositoryServiceTest extends BaseServiceTest {
             assertThat(pullRequestsId)
                     .containsExactly(nowPr.getId(), oneMinutesAgoPR.getId(), threeMinutesAgoPR.getId(),
                             fiveMinutesAgoPR.getId());
+        }
+
+        @Test
+        void 회원의_전체_풀_리퀘스트_목록_중_질문_생성이_완료된_것만_머지_최신순으로_가져온다() {
+            LocalDateTime now = LocalDateTime.now();
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo1 = repoGenerator.generate(user, "김건우의 레포지토리1");
+            GithubRepository repo2 = repoGenerator.generate(user, "김건우의 레포지토리2");
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.PROCESSING, repo1, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
+            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo2, now);
+
+            List<Long> pullRequestsId = repositoryService.getProcessedPullRequests(user, 4, 0)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            assertThat(pullRequestsId)
+                    .containsExactly(nowPr.getId(), oneMinutesAgoPR.getId(), fiveMinutesAgoPR.getId());
         }
 
         @Test
@@ -162,13 +238,13 @@ class RepositoryServiceTest extends BaseServiceTest {
                     ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
             PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo2, now);
 
-            List<Long> pageOneIds = repositoryService.getPullRequests(user, 2, 0)
+            List<Long> pageOneIds = repositoryService.getProcessedPullRequests(user, 2, 0)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
                     .toList();
 
-            List<Long> pageTwoIds = repositoryService.getPullRequests(user, 2, 1)
+            List<Long> pageTwoIds = repositoryService.getProcessedPullRequests(user, 2, 1)
                     .getValues()
                     .stream()
                     .map(PullRequest::getId)
@@ -179,7 +255,42 @@ class RepositoryServiceTest extends BaseServiceTest {
                     () -> assertThat(pageTwoIds).containsOnly(threeMinutesAgoPR.getId(), fiveMinutesAgoPR.getId())
             );
         }
+
+        @Test
+        void 질문_생성이_완료된_풀_리퀘스트_목록에_페이지네이션을_적용한다() {
+            LocalDateTime now = LocalDateTime.now();
+            User user = userGenerator.generate("김건우");
+            GithubRepository repo1 = repoGenerator.generate(user, "김건우의 레포지토리1");
+            GithubRepository repo2 = repoGenerator.generate(user, "김건우의 레포지토리2");
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
+            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.PROCESSING, repo2, now);
+
+            List<Long> pageOneIds = repositoryService.getProcessedPullRequests(user, 2, 0)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            List<Long> pageTwoIds = repositoryService.getProcessedPullRequests(user, 2, 1)
+                    .getValues()
+                    .stream()
+                    .map(PullRequest::getId)
+                    .toList();
+
+            assertAll(
+                    () -> assertThat(pageOneIds).containsOnly(oneMinutesAgoPR.getId(), threeMinutesAgoPR.getId()),
+                    () -> assertThat(pageTwoIds).containsOnly(fiveMinutesAgoPR.getId())
+            );
+        }
     }
+
+
 
     @Nested
     class StopTracking {

--- a/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/repository/RepositoryServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.devoops.BaseServiceTest;
 import com.devoops.command.request.RepositoryCreateCommand;
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
@@ -58,12 +59,12 @@ class RepositoryServiceTest extends BaseServiceTest {
             LocalDateTime now = LocalDateTime.now();
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
-            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(5L));
-            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(3L));
-            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(1L));
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(1L));
 
             List<Long> pullRequestsId = repositoryService.getPullRequestsByRepository(user, repo.getId(), 6, 0)
                     .getValues()
@@ -80,12 +81,12 @@ class RepositoryServiceTest extends BaseServiceTest {
             LocalDateTime now = LocalDateTime.now();
             User user = userGenerator.generate("김건우");
             GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
-            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(5L));
-            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(3L));
-            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo,
-                    now.minusMinutes(1L));
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo, now.minusMinutes(1L));
 
             List<Long> pageOneIds = repositoryService.getPullRequestsByRepository(user, repo.getId(), 2, 0)
                     .getValues()
@@ -111,7 +112,7 @@ class RepositoryServiceTest extends BaseServiceTest {
             User user = userGenerator.generate("김건우");
             User seonwoo = userGenerator.generate("선우 누나");
             GithubRepository repo = repoGenerator.generate(user, "김건우의 레포지토리");
-            pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo, now);
+            pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo, now);
 
             assertThatThrownBy(() -> repositoryService.getPullRequestsByRepository(seonwoo, repo.getId(), 6, 0))
                     .isInstanceOf(GssException.class)
@@ -128,13 +129,13 @@ class RepositoryServiceTest extends BaseServiceTest {
             User user = userGenerator.generate("김건우");
             GithubRepository repo1 = repoGenerator.generate(user, "김건우의 레포지토리1");
             GithubRepository repo2 = repoGenerator.generate(user, "김건우의 레포지토리2");
-            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo1,
-                    now.minusMinutes(5L));
-            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo1,
-                    now.minusMinutes(3L));
-            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo2,
-                    now.minusMinutes(1L));
-            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo2, now);
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
+            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo2, now);
 
             List<Long> pullRequestsId = repositoryService.getPullRequests(user, 4, 0)
                     .getValues()
@@ -153,13 +154,13 @@ class RepositoryServiceTest extends BaseServiceTest {
             User user = userGenerator.generate("김건우");
             GithubRepository repo1 = repoGenerator.generate(user, "김건우의 레포지토리1");
             GithubRepository repo2 = repoGenerator.generate(user, "김건우의 레포지토리2");
-            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING, repo1,
-                    now.minusMinutes(5L));
-            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING, repo1,
-                    now.minusMinutes(3L));
-            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo2,
-                    now.minusMinutes(1L));
-            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, repo2, now);
+            PullRequest fiveMinutesAgoPR = pullRequestGenerator.generate("5분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(5L));
+            PullRequest threeMinutesAgoPR = pullRequestGenerator.generate("3분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo1, now.minusMinutes(3L));
+            PullRequest oneMinutesAgoPR = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING,
+                    ProcessingStatus.DONE, repo2, now.minusMinutes(1L));
+            PullRequest nowPr = pullRequestGenerator.generate("1분전 PR", RecordStatus.PENDING, ProcessingStatus.DONE, repo2, now);
 
             List<Long> pageOneIds = repositoryService.getPullRequests(user, 2, 0)
                     .getValues()

--- a/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
+++ b/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
@@ -44,7 +44,7 @@ public record PullRequestCreateCommand(
                 summaryDetail,
                 pullRequestUrl,
                 externalId,
-                RecordStatus.PENDING,
+                recordStatus,
                 ProcessingStatus.PROCESSING,
                 mergedAt,
                 tag

--- a/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
+++ b/gss-domain/src/main/java/com/devoops/command/request/PullRequestCreateCommand.java
@@ -1,22 +1,22 @@
 package com.devoops.command.request;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
-
 import java.time.LocalDateTime;
 
 public record PullRequestCreateCommand(
-    long repositoryId,
-    long userId,
-    String title,
-    String description,
-    String summary,
-    String summaryDetail,
-    String pullRequestUrl,
-    long externalId,
-    RecordStatus recordStatus,
-    LocalDateTime mergedAt,
-    String tag
+        long repositoryId,
+        long userId,
+        String title,
+        String description,
+        String summary,
+        String summaryDetail,
+        String pullRequestUrl,
+        long externalId,
+        RecordStatus recordStatus,
+        LocalDateTime mergedAt,
+        String tag
 ) {
 
     public PullRequestCreateCommand(
@@ -29,39 +29,25 @@ public record PullRequestCreateCommand(
             String tag,
             LocalDateTime mergedAt
     ) {
-        this(repositoryId, userId, title, description, "", "", pullRequestUrl, externalId, RecordStatus.PENDING, mergedAt, tag);
-    }
-
-
-    public PullRequestCreateCommand(
-            long repositoryId,
-            long userId,
-            String title,
-            String description,
-            String summary,
-            String summaryDetail,
-            String pullRequestUrl,
-            long externalId,
-            String tag,
-            LocalDateTime mergedAt
-    ) {
-        this(repositoryId, userId, title, description, summary, summaryDetail, pullRequestUrl, externalId, RecordStatus.PENDING, mergedAt, tag);
+        this(repositoryId, userId, title, description, "", "", pullRequestUrl, externalId, RecordStatus.PENDING,
+                mergedAt, tag);
     }
 
     public PullRequest toDomainEntity() {
         return new PullRequest(
-            null,
-            repositoryId,
-            userId,
-            title,
-            description,
-            summary,
-            summaryDetail,
-            pullRequestUrl,
-            externalId,
-            RecordStatus.PENDING,
-            mergedAt,
-            tag
+                null,
+                repositoryId,
+                userId,
+                title,
+                description,
+                summary,
+                summaryDetail,
+                pullRequestUrl,
+                externalId,
+                RecordStatus.PENDING,
+                ProcessingStatus.PROCESSING,
+                mergedAt,
+                tag
         );
     }
 }

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/pr/ProcessingStatus.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/pr/ProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.devoops.domain.entity.github.pr;
+
+public enum ProcessingStatus {
+
+    PROCESSING,
+    DONE,
+    ;
+}

--- a/gss-domain/src/main/java/com/devoops/domain/entity/github/pr/PullRequest.java
+++ b/gss-domain/src/main/java/com/devoops/domain/entity/github/pr/PullRequest.java
@@ -19,6 +19,7 @@ public class PullRequest {
     private final String pullRequestUrl;
     private final long externalId;
     private final RecordStatus recordStatus;
+    private final ProcessingStatus processingStatus;
     private final LocalDateTime mergedAt;
     private final String tag;
 

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/pr/PullRequestDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/pr/PullRequestDomainRepository.java
@@ -10,11 +10,11 @@ public interface PullRequestDomainRepository {
 
     PullRequest findById(long pullRequestId);
 
-    PullRequests findPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page);
+    PullRequests findProcessedPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page);
 
     PullRequest updateAnalyzedResult(long pullRequestId, String summary, String detailSummary);
 
-    PullRequests findUserPullRequestsOrderByMergedAt(long userId, int size, int page);
+    PullRequests findProcessedUserPullRequestsOrderByMergedAt(long userId, int size, int page);
 
     PullRequest findByQuestionId(long questionId);
 

--- a/gss-domain/src/main/java/com/devoops/domain/repository/github/pr/PullRequestDomainRepository.java
+++ b/gss-domain/src/main/java/com/devoops/domain/repository/github/pr/PullRequestDomainRepository.java
@@ -18,9 +18,5 @@ public interface PullRequestDomainRepository {
 
     PullRequest findByQuestionId(long questionId);
 
-    PullRequests findByRepositoryId(long repositoryId);
-
     PullRequest updateStatus(long pullRequestId, RecordStatus status);
-
-    void deleteAll(PullRequests pullRequests);
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
@@ -60,7 +60,7 @@ public class PullRequestEntity extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    @ColumnDefault("DONE")
+    @ColumnDefault("'DONE'")
     private ProcessingStatus processingStatus;
 
     @NotNull

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
@@ -87,6 +87,7 @@ public class PullRequestEntity extends BaseTimeEntity {
     }
 
     public void updateAnalyzeResult(String summary, String summaryDetail) {
+        this.processingStatus = ProcessingStatus.DONE;
         this.summary = summary;
         this.summaryDetail = summaryDetail;
     }

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -59,6 +60,7 @@ public class PullRequestEntity extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("DONE")
     private ProcessingStatus processingStatus;
 
     @NotNull

--- a/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/entity/github/pr/PullRequestEntity.java
@@ -1,5 +1,6 @@
 package com.devoops.jpa.entity.github.pr;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
 import com.devoops.jpa.entity.BaseTimeEntity;
@@ -57,6 +58,10 @@ public class PullRequestEntity extends BaseTimeEntity {
     private RecordStatus recordStatus;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
+    private ProcessingStatus processingStatus;
+
+    @NotNull
     private LocalDateTime mergedAt;
 
     public static PullRequestEntity from(PullRequest pullRequest) {
@@ -72,6 +77,7 @@ public class PullRequestEntity extends BaseTimeEntity {
                 pullRequest.getExternalId(),
                 pullRequest.getPullRequestUrl(),
                 pullRequest.getRecordStatus(),
+                pullRequest.getProcessingStatus(),
                 pullRequest.getMergedAt()
         );
     }
@@ -97,6 +103,7 @@ public class PullRequestEntity extends BaseTimeEntity {
                 this.pullRequestUrl,
                 this.githubPullRequestId,
                 this.recordStatus,
+                this.processingStatus,
                 this.mergedAt,
                 this.tag
         );

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
@@ -31,9 +31,6 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
     @Override
     @Transactional
     public PullRequest save(PullRequest pullRequest) {
-        GithubRepositoryEntity githubRepositoryEntity = githubRepoRepository.findById(pullRequest.getRepositoryId())
-                .orElseThrow(() -> new GssException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND));
-        githubRepositoryEntity.plusPrCount();
         PullRequestEntity pullRequestEntity = PullRequestEntity.from(pullRequest);
         PullRequestEntity savedPullRequest = pullRequestRepository.save(pullRequestEntity);
         return savedPullRequest.toDomainEntity();
@@ -82,6 +79,9 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
         PullRequestEntity pullRequest = pullRequestRepository.findById(pullRequestId)
                 .orElseThrow(() -> new GssException(ErrorCode.PULL_REQUEST_NOT_FOUND));
         pullRequest.updateAnalyzeResult(summary, detailSummary);
+        GithubRepositoryEntity githubRepositoryEntity = githubRepoRepository.findById(pullRequest.getRepositoryId())
+                .orElseThrow(() -> new GssException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND));
+        githubRepositoryEntity.plusPrCount();
         return pullRequest.toDomainEntity();
     }
 

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
@@ -1,17 +1,17 @@
 package com.devoops.jpa.repository.github.pr;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.PullRequests;
 import com.devoops.domain.entity.github.pr.RecordStatus;
 import com.devoops.domain.repository.github.pr.PullRequestDomainRepository;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
-import com.devoops.jpa.entity.github.repo.GithubRepositoryEntity;
 import com.devoops.jpa.entity.github.pr.PullRequestEntity;
 import com.devoops.jpa.entity.github.question.QuestionEntity;
+import com.devoops.jpa.entity.github.repo.GithubRepositoryEntity;
 import com.devoops.jpa.repository.github.question.QuestionJpaRepository;
 import com.devoops.jpa.repository.github.repo.GithubRepoJpaRepository;
-import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -46,9 +46,9 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
 
     @Override
     @Transactional(readOnly = true)
-    public PullRequests findPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page) {
+    public PullRequests findProcessedPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "mergedAt"));
-        return pullRequestRepository.findByRepositoryId(repositoryId, pageable)
+        return pullRequestRepository.findByRepositoryIdAndProcessingStatus(repositoryId, ProcessingStatus.DONE, pageable)
                 .get()
                 .map(PullRequestEntity::toDomainEntity)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));
@@ -56,9 +56,9 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
 
     @Override
     @Transactional(readOnly = true)
-    public PullRequests findUserPullRequestsOrderByMergedAt(long userId, int size, int page) {
+    public PullRequests findProcessedUserPullRequestsOrderByMergedAt(long userId, int size, int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "mergedAt"));
-        return pullRequestRepository.findByUserId(userId, pageable)
+        return pullRequestRepository.findByUserIdAndProcessingStatus(userId, ProcessingStatus.DONE, pageable)
                 .get()
                 .map(PullRequestEntity::toDomainEntity)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
@@ -49,7 +49,7 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
     public PullRequests findProcessedPullRequestsByRepositoryIdOrderByMergedAt(long repositoryId, int size, int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "mergedAt"));
         return pullRequestRepository.findByRepositoryIdAndProcessingStatus(repositoryId, ProcessingStatus.DONE, pageable)
-                .get()
+                .stream()
                 .map(PullRequestEntity::toDomainEntity)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));
     }
@@ -59,7 +59,7 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
     public PullRequests findProcessedUserPullRequestsOrderByMergedAt(long userId, int size, int page) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "mergedAt"));
         return pullRequestRepository.findByUserIdAndProcessingStatus(userId, ProcessingStatus.DONE, pageable)
-                .get()
+                .stream()
                 .map(PullRequestEntity::toDomainEntity)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));
     }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestDomainRepositoryImpl.java
@@ -94,23 +94,4 @@ public class PullRequestDomainRepositoryImpl implements PullRequestDomainReposit
                 .orElseThrow(() -> new GssException(ErrorCode.PULL_REQUEST_NOT_FOUND))
                 .toDomainEntity();
     }
-
-    @Override
-    @Transactional(readOnly = true)
-    public PullRequests findByRepositoryId(long repositoryId) {
-         return pullRequestRepository.findAllByRepositoryId(repositoryId)
-                 .stream()
-                 .map(PullRequestEntity::toDomainEntity)
-                 .collect(Collectors.collectingAndThen(Collectors.toList(), PullRequests::new));
-    }
-
-    @Override
-    @Transactional
-    public void deleteAll(PullRequests pullRequests) {
-        List<PullRequestEntity> pullRequestEntities = pullRequests.getValues()
-                .stream()
-                .map(PullRequestEntity::from)
-                .toList();
-        pullRequestRepository.deleteAll(pullRequestEntities);
-    }
 }

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestJpaRepository.java
@@ -2,7 +2,6 @@ package com.devoops.jpa.repository.github.pr;
 
 import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.jpa.entity.github.pr.PullRequestEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PullRequestJpaRepository extends JpaRepository<PullRequestEntity, Long> {
 
-    Page<PullRequestEntity> findByRepositoryIdAndProcessingStatus(long repositoryId, ProcessingStatus processingStatus, Pageable pageable);
+    Page<PullRequestEntity> findByRepositoryIdAndProcessingStatus(
+            long repositoryId,
+            ProcessingStatus processingStatus,
+            Pageable pageable
+    );
 
     Page<PullRequestEntity> findByUserIdAndProcessingStatus(long userId, ProcessingStatus status, Pageable pageable);
 

--- a/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestJpaRepository.java
+++ b/gss-domain/src/main/java/com/devoops/jpa/repository/github/pr/PullRequestJpaRepository.java
@@ -1,5 +1,6 @@
 package com.devoops.jpa.repository.github.pr;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.jpa.entity.github.pr.PullRequestEntity;
 import java.util.List;
 import java.util.Optional;
@@ -9,11 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PullRequestJpaRepository extends JpaRepository<PullRequestEntity, Long> {
 
-    Page<PullRequestEntity> findByRepositoryId(long repositoryId, Pageable pageable);
+    Page<PullRequestEntity> findByRepositoryIdAndProcessingStatus(long repositoryId, ProcessingStatus processingStatus, Pageable pageable);
 
-    Page<PullRequestEntity> findByUserId(long userId, Pageable pageable);
+    Page<PullRequestEntity> findByUserIdAndProcessingStatus(long userId, ProcessingStatus status, Pageable pageable);
 
     Optional<PullRequestEntity> findById(long id);
-
-    List<PullRequestEntity> findAllByRepositoryId(long repositoryId);
 }

--- a/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -38,12 +38,12 @@ public class RepositoryService {
     }
 
     public PullRequests getPullRequests(User user, int size, int page) {
-        return pullRequestRepository.findUserPullRequestsOrderByMergedAt(user.getId(), size, page);
+        return pullRequestRepository.findProcessedUserPullRequestsOrderByMergedAt(user.getId(), size, page);
     }
 
     public PullRequests getPullRequestsByRepository(User user, long repositoryId, int size, int page) {
         validateOwn(user, repositoryId);
-        return pullRequestRepository.findPullRequestsByRepositoryIdOrderByMergedAt(repositoryId, size, page);
+        return pullRequestRepository.findProcessedPullRequestsByRepositoryIdOrderByMergedAt(repositoryId, size, page);
     }
 
     private void validateOwn(User user, long repositoryId) {

--- a/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
+++ b/gss-domain/src/main/java/com/devoops/service/repository/RepositoryService.java
@@ -37,11 +37,11 @@ public class RepositoryService {
         return repoRepository.update(reTrackingRepo);
     }
 
-    public PullRequests getPullRequests(User user, int size, int page) {
+    public PullRequests getProcessedPullRequests(User user, int size, int page) {
         return pullRequestRepository.findProcessedUserPullRequestsOrderByMergedAt(user.getId(), size, page);
     }
 
-    public PullRequests getPullRequestsByRepository(User user, long repositoryId, int size, int page) {
+    public PullRequests getProcessedPullRequestsByRepository(User user, long repositoryId, int size, int page) {
         validateOwn(user, repositoryId);
         return pullRequestRepository.findProcessedPullRequestsByRepositoryIdOrderByMergedAt(repositoryId, size, page);
     }

--- a/gss-domain/src/testFixtures/java/com/devoops/generator/PullRequestGenerator.java
+++ b/gss-domain/src/testFixtures/java/com/devoops/generator/PullRequestGenerator.java
@@ -1,5 +1,6 @@
 package com.devoops.generator;
 
+import com.devoops.domain.entity.github.pr.ProcessingStatus;
 import com.devoops.domain.entity.github.repo.GithubRepository;
 import com.devoops.domain.entity.github.pr.PullRequest;
 import com.devoops.domain.entity.github.pr.RecordStatus;
@@ -15,7 +16,13 @@ public class PullRequestGenerator {
     @Autowired
     private PullRequestDomainRepository pullRequestDomainRepository;
 
-    public PullRequest generate(String title, RecordStatus status, GithubRepository githubRepository, LocalDateTime mergedAt) {
+    public PullRequest generate(
+            String title,
+            RecordStatus status,
+            ProcessingStatus processingStatus,
+            GithubRepository githubRepository,
+            LocalDateTime mergedAt
+    ) {
         PullRequest pullRequest = new PullRequest(
             null,
             githubRepository.getId(),
@@ -27,6 +34,7 @@ public class PullRequestGenerator {
             "https://github.com/owner/repo/pull/2",
             1L,
             status,
+            processingStatus,
             mergedAt,
             "tag"
         );

--- a/gss-mcp-app/src/test/java/com/devoops/service/webhook/WebhookFacadeServiceTest.java
+++ b/gss-mcp-app/src/test/java/com/devoops/service/webhook/WebhookFacadeServiceTest.java
@@ -52,7 +52,7 @@ class WebhookFacadeServiceTest extends BaseMcpTest {
             webhookFacadeService.createQuestionWithWebhookEvent(appRequest);
             Thread.sleep(1000L); //CountDownLatch로 수정
 
-            PullRequests pullRequests = pullRequestDomainRepository.findUserPullRequestsOrderByMergedAt(user.getId(), 2,
+            PullRequests pullRequests = pullRequestDomainRepository.findProcessedUserPullRequestsOrderByMergedAt(user.getId(), 2,
                     0);
             long savedPrId = pullRequests.getValues().get(0).getId();
             List<QuestionAnswer> questions = questionDomainRepository.findAllPrQuestions(savedPrId);


### PR DESCRIPTION
# 🚩 연관 이슈
close #86 

# 🔂 변경 내역


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - PR에 처리 상태(처리중/완료) 정보가 UI/API에 노출됩니다.

- 변경 사항
  - 사용자·저장소 PR 목록은 '완료' 처리된 항목만 반환하며 페이지네이션·정렬도 해당 기준으로 동작합니다.
  - 신규 PR은 기본적으로 '처리중'으로 생성되고 분석 완료 시 '완료'로 전환되며, 완료 시 저장소의 PR 카운트가 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->