### PR TITLE
[REFACOTR] 레포 등록시 깃허브 웹훅 등록 과정에서 403에러를 애플리케이션 에러로 전환

### DIFF
--- a/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
+++ b/gss-api-app/src/main/java/com/devoops/service/facade/RepositoryFacadeService.java
@@ -10,6 +10,7 @@ import com.devoops.dto.request.GithubRepoUrl;
 import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.event.AnalyzeMyPrEvent;
+import com.devoops.exception.GithubForbiddenException;
 import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
@@ -42,7 +43,7 @@ public class RepositoryFacadeService {
 
             eventPublisher.publishEvent(new AnalyzeMyPrEvent(repoUrl, user, this));
             return savedRepository;
-        } catch (GithubNotFoundException githubNotFoundException) {
+        } catch (GithubNotFoundException | GithubForbiddenException githubException) {
             throw new GssException(ErrorCode.REGISTRY_GITHUB_REPOSITORY_NOT_FOUND);
         }
     }

--- a/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
+++ b/gss-api-app/src/test/java/com/devoops/service/facade/RepositoryFacadeServiceTest.java
@@ -18,6 +18,7 @@ import com.devoops.dto.request.RepositorySaveRequest;
 import com.devoops.dto.response.GithubRepoInfoResponse;
 import com.devoops.dto.response.OwnerResponse;
 import com.devoops.dto.response.WebHookCreateResponse;
+import com.devoops.exception.GithubForbiddenException;
 import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
@@ -59,10 +60,21 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
         }
 
         @Test
-        void 웹훅_등록_실패_시_애플리케이션_에러로_전환한다() {
+        void 웹훅_등록_시_404_에러가_발생하면_애플리케이션_에러로_전환한다() {
             User user = userGenerator.generate("김건우");
             RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
-            mockingErrorWhenCreateWebHook();
+            mockingErrorWhenCreateWebHook(new GithubNotFoundException("mocking error"));
+
+            assertThatThrownBy(() -> repositoryFacadeService.save(request, user))
+                    .isInstanceOf(GssException.class)
+                    .hasMessage(ErrorCode.REGISTRY_GITHUB_REPOSITORY_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 웹훅_등록_시_403_에러가_발생하면_애플리케이션_에러로_전환한다() {
+            User user = userGenerator.generate("김건우");
+            RepositorySaveRequest request = new RepositorySaveRequest("https://github.com/octocat/Hello-World");
+            mockingErrorWhenCreateWebHook(new GithubForbiddenException("mocking error"));
 
             assertThatThrownBy(() -> repositoryFacadeService.save(request, user))
                     .isInstanceOf(GssException.class)
@@ -121,14 +133,14 @@ class RepositoryFacadeServiceTest extends BaseServiceTest {
                     .thenReturn(mockWebHookCreateResponse);
         }
 
-        private void mockingErrorWhenCreateWebHook() {
+        private void mockingErrorWhenCreateWebHook(Exception exception) {
             GithubRepoInfoResponse mockResponse = new GithubRepoInfoResponse(123, "testName", "testUrl",
                     new OwnerResponse("김건우"));
             WebHookCreateResponse mockWebHookCreateResponse = new WebHookCreateResponse(123);
             Mockito.when(gitHubClient.getRepositoryInfo(anyString(), anyString(), anyString()))
                     .thenReturn(mockResponse);
             Mockito.when(gitHubClient.createWebhook(any(), any(), any(), any()))
-                    .thenThrow(new GithubNotFoundException("mocking error"));
+                    .thenThrow(exception);
         }
     }
 

--- a/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/client/GithubExchangeFilterFunction.java
@@ -1,5 +1,6 @@
 package com.devoops.client;
 
+import com.devoops.exception.GithubForbiddenException;
 import com.devoops.exception.GithubNotFoundException;
 import com.devoops.exception.custom.GssException;
 import com.devoops.exception.errorcode.ErrorCode;
@@ -29,6 +30,9 @@ public class GithubExchangeFilterFunction {
                             ));
                             if (response.statusCode().isSameCodeAs(HttpStatusCode.valueOf(404))) {
                                 return Mono.error(new GithubNotFoundException("깃허브에서 자원을 찾을 수 없습니다."));
+                            }
+                            if(response.statusCode().isSameCodeAs(HttpStatusCode.valueOf(403))) {
+                                return Mono.error(new GithubForbiddenException("깃허브 자원의 접근 권한이 없습니다"));
                             }
                             return Mono.error(new GssException(ErrorCode.GITHUB_CLIENT_ERROR));
                         });

--- a/gss-client/gss-github-client/src/main/java/com/devoops/exception/GithubForbiddenException.java
+++ b/gss-client/gss-github-client/src/main/java/com/devoops/exception/GithubForbiddenException.java
@@ -1,0 +1,8 @@
+package com.devoops.exception;
+
+public class GithubForbiddenException extends RuntimeException {
+
+    public GithubForbiddenException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈
closd #92 

# 🔂 변경 내역


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 깃허브 403(권한 없음) 응답을 명시적으로 처리하여 권한 부족 시 사용자 친화적 오류 메시지를 제공합니다.
* 버그 수정
  * 저장/웹훅 생성 과정에서 발생하는 403/404 응답을 일관되게 처리해 오류 안내 신뢰성을 높였습니다.
* 테스트
  * 403(권한 없음), 404(리소스 없음) 시나리오에 대한 단위 테스트를 추가하여 오류 처리 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->